### PR TITLE
Migrate recent development on HAKES index

### DIFF
--- a/docker/search-worker/no-sgx/Dockerfile
+++ b/docker/search-worker/no-sgx/Dockerfile
@@ -1,4 +1,4 @@
-FROM hakes_es_base_nosgx:v1 as search_worker_builder
+FROM intel/oneapi:2025.0.0-0-devel-ubuntu24.04 as search_worker_builder
 
 USER root
 
@@ -8,17 +8,14 @@ RUN apt-get update && apt-get install -y libssl-dev
 COPY --from=hakes_es_base_nosgx:v1 /hakes-es/deps /hakes-es/deps
 COPY ./search-worker/ /hakes-es/search-worker
 COPY ./message/ /hakes-es/message
-COPY ./ratls-channel/ /hakes-es/ratls-channel
-COPY ./secret/ /hakes-es/secret
 COPY ./server/ /hakes-es/server
-COPY ./store-client/ /hakes-es/store-client
 COPY ./utils/ /hakes-es/utils
 
 RUN cd /hakes-es/search-worker \
   && make mrproper && make no_sgx && make install && cd ..
 
 # image
-FROM ubuntu:20.04
+FROM intel/oneapi:2025.0.0-0-devel-ubuntu24.04
 
 USER root
 

--- a/docker/search-worker/no-sgx/README.md
+++ b/docker/search-worker/no-sgx/README.md
@@ -9,5 +9,5 @@ docker build -t hakes-searchworker-nosgx:v1 -f docker/search-worker/no-sgx/Docke
 ## run
 
 ```sh
-docker run --name search-worker-test -p 2053:8080 -v $PWD/data/searchworker/sample-index/index_opq_ivfpq_glove-200_OPQ100_M50_nlist1024_hakesindex_base_index_withdata:/mounted_store/index hakes-searchworker-nosgx:v1
+docker run --name search-worker-test -p 2053:8080 -v $PWD/data/searchworker-sampledata/:/mounted_store/index hakes-searchworker-nosgx:v1
 ```

--- a/search-worker/include/search-worker/common/worker.h
+++ b/search-worker/include/search-worker/common/worker.h
@@ -19,6 +19,8 @@
 
 #include <cstddef>
 
+#include "utils/io.h"
+
 namespace search_worker {
 
 class Worker {
@@ -26,7 +28,9 @@ class Worker {
   Worker() = default;
   virtual ~Worker() {}
 
-  virtual bool Initialize(const char* index_data, size_t index_len, int cluster_size, int server_id) = 0;
+  virtual bool Initialize(hakes::IOReader* ff, hakes::IOReader* rf,
+                          hakes::IOReader* uf, bool keep_pa, int cluster_size,
+                          int server_id) = 0;
 
   // the worker shall be pre-initialized before installing to a search worker
   virtual bool IsInitialized() = 0;

--- a/search-worker/include/search-worker/common/workerImpl.h
+++ b/search-worker/include/search-worker/common/workerImpl.h
@@ -31,7 +31,8 @@ class WorkerImpl : public Worker {
   WorkerImpl() = default;
   virtual ~WorkerImpl() {}
 
-  bool Initialize(const char* index_data, size_t index_len, int cluster_size, int server_id) override;
+  bool Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf,
+                  bool keep_pa, int cluster_size, int server_id) override;
 
   bool IsInitialized() override;
 

--- a/search-worker/index/VectorTransform.cpp
+++ b/search-worker/index/VectorTransform.cpp
@@ -20,33 +20,35 @@
 #include "search-worker/index/utils/distances.h"
 #include "search-worker/index/utils/random.h"
 #include "search-worker/index/utils/utils.h"
-#include "search-worker/index/blas/sgemm.h"
 
 using namespace faiss;
 
-// extern "C" {
+#ifdef USE_SGX
+#include "search-worker/index/blas/sgemm.h"
+#else // USE_SGX
+extern "C" {
 
-// // this is to keep the clang syntax checker happy
-// #ifndef FINTEGER
-// #define FINTEGER int
-// #endif
+// this is to keep the clang syntax checker happy
+#ifndef FINTEGER
+#define FINTEGER long
+#endif
 
 // /* declare BLAS functions, see http://www.netlib.org/clapack/cblas/ */
 
-// int sgemm_(
-//         const char* transa,
-//         const char* transb,
-//         FINTEGER* m,
-//         FINTEGER* n,
-//         FINTEGER* k,
-//         const float* alpha,
-//         const float* a,
-//         FINTEGER* lda,
-//         const float* b,
-//         FINTEGER* ldb,
-//         float* beta,
-//         float* c,
-//         FINTEGER* ldc);
+int sgemm_(
+        const char* transa,
+        const char* transb,
+        FINTEGER* m,
+        FINTEGER* n,
+        FINTEGER* k,
+        const float* alpha,
+        const float* a,
+        FINTEGER* lda,
+        const float* b,
+        FINTEGER* ldb,
+        float* beta,
+        float* c,
+        FINTEGER* ldc);
 
 // int dgemm_(
 //         const char* transa,
@@ -130,7 +132,8 @@ using namespace faiss;
 //         double* work,
 //         FINTEGER* lwork,
 //         FINTEGER* info);
-// }
+}
+#endif // USE_SGX
 
 /*********************************************
  * VectorTransform

--- a/search-worker/index/ext/BlockInvertedListsL.cpp
+++ b/search-worker/index/ext/BlockInvertedListsL.cpp
@@ -209,12 +209,12 @@ BlockInvertedListsL::~BlockInvertedListsL() {
     delete packer_;
   }
 }
-void InvListUnit::write(IOWriter* f) const {
+void InvListUnit::write(hakes::IOWriter* f) const {
   WRITEVECTOR(ids_);
   WRITEVECTOR(codes_);
 }
 
-void InvListUnit::read(IOReader* f) {
+void InvListUnit::read(hakes::IOReader* f) {
   READVECTOR(ids_);
   READVECTOR(codes_);
   count_.store(ids_.size(), std::memory_order_relaxed);

--- a/search-worker/index/ext/BlockInvertedListsL.h
+++ b/search-worker/index/ext/BlockInvertedListsL.h
@@ -21,7 +21,7 @@
 
 #include <atomic>
 
-#include "search-worker/index/impl/io.h"
+#include "utils/io.h"
 #include "search-worker/index/invlists/InvertedLists.h"
 #include "search-worker/index/utils/AlignedTable.h"
 
@@ -90,8 +90,8 @@ struct InvListUnit {
   inline void lock_exclusive() const { pthread_rwlock_wrlock(&mu_); }
   inline void unlock_exclusive() const { pthread_rwlock_unlock(&mu_); }
 
-  void read(IOReader* f);
-  void write(IOWriter* f) const;
+  void read(hakes::IOReader* f);
+  void write(hakes::IOWriter* f) const;
 };
 
 /** Inverted Lists that are organized by blocks.

--- a/search-worker/index/ext/HakesIndex.cpp
+++ b/search-worker/index/ext/HakesIndex.cpp
@@ -26,11 +26,11 @@
 namespace faiss {
 
 bool HakesIndex::Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf, bool keep_pa) {
-  bool success = load_hakes_index(ff, rf, this, keep_pa);
+  bool success = load_hakes_index_new(ff, rf, this, keep_pa);
   if (uf != nullptr) {
     // load query index
     faiss::HakesIndex update_index;
-    success = load_hakes_index(uf, nullptr, &update_index, keep_pa);
+    success = load_hakes_index_new(uf, nullptr, &update_index, keep_pa);
     this->UpdateIndex(update_index);
   } else if (use_ivf_sq_) {
     // no query index provided, apply sq to the ivf centroids

--- a/search-worker/index/ext/HakesIndex.cpp
+++ b/search-worker/index/ext/HakesIndex.cpp
@@ -16,6 +16,7 @@
 
 #include "search-worker/index/ext/HakesIndex.h"
 
+#include <stdexcept>
 #include <vector>
 
 #include "search-worker/index/ext/IndexIVFFastScanL.h"

--- a/search-worker/index/ext/HakesIndex.cpp
+++ b/search-worker/index/ext/HakesIndex.cpp
@@ -19,61 +19,40 @@
 #include <vector>
 
 #include "search-worker/index/ext/IndexIVFFastScanL.h"
+#include "search-worker/index/ext/IndexScalarQuantizerL.h"
 #include "search-worker/index/ext/index_io_ext.h"
 #include "search-worker/index/ext/utils.h"
-#include "search-worker/index/impl/io.h"
 
 namespace faiss {
 
-bool HakesIndex::Initialize(IOReader* f, bool params_only) {
-  if (!params_only) {
-    mapping_.reset(new faiss::IDMapImpl());
-    bool success = load_hakes_index_single_file(f, this);
-    if (success) {
-      cq_ = base_index_->quantizer;
-      share_vt_ = (cq_->d == base_index_->d);
+bool HakesIndex::Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf, bool keep_pa) {
+  bool success = load_hakes_index(ff, rf, this, keep_pa);
+  if (uf != nullptr) {
+    // load query index
+    faiss::HakesIndex update_index;
+    success = load_hakes_index(uf, nullptr, &update_index, keep_pa);
+    this->UpdateIndex(update_index);
+  } else if (use_ivf_sq_) {
+    // no query index provided, apply sq to the ivf centroids
+    auto tmp = new IndexScalarQuantizerL(
+        base_index_->d,
+        ScalarQuantizer::QuantizerType::QT_8bit_direct,
+        faiss::MetricType::METRIC_L2);
+    int nlist = base_index_->quantizer->get_ntotal();
+    auto scaled_codes = std::vector<float>(nlist * base_index_->d);
+    const float* to_scale = (const float*)static_cast<IndexFlatL*>(
+                                base_index_->quantizer)
+                                ->codes.data();
+    for (int i = 0; i < nlist * base_index_->d; i++) {
+      scaled_codes[i] = to_scale[i] * 127 + 128;
     }
-    return success;
-  }
-  {
-    // load base index
-    auto loaded_index =
-        faiss::load_hakes_vt_quantizers(f, faiss::METRIC_INNER_PRODUCT, &vts_);
-    if (!loaded_index) {
-      throw std::runtime_error("Failed to load index from IOReader");
-    }
-    // printf("Loaded base index from IOReader\n");
-    base_index_.reset(dynamic_cast<faiss::IndexIVFPQFastScanL*>(loaded_index));
-    if (!base_index_) {
-      throw std::runtime_error("Failed to cast to IndexIVFPQFastScanL");
-    }
+    tmp->add(nlist, scaled_codes.data());
+    cq_ = tmp;
+  } else {
+    // no query index provided, just access the ivf centroids
     cq_ = base_index_->quantizer;
-    if (!cq_) {
-      throw std::runtime_error("Failed to cast to Quantizer");
-    }
   }
-  {
-    // create refine index
-    int d = base_index_->d;
-    if (!vts_.empty()) {
-      d = vts_.front()->d_in;
-    }
-    refine_index_.reset(new faiss::IndexFlatL(d, base_index_->metric_type));
-    // printf("Created refine index with dimension %d\n", d);
-  }
-  {
-    // create id mapping
-    mapping_.reset(new faiss::IDMapImpl());
-    // printf("Created id mapping\n");
-  }
-
-  share_vt_ = (cq_->d == base_index_->d);
-
-  if (mapping_->size() != refine_index_->ntotal) {
-    throw std::runtime_error("mapping size not equal to refine index size");
-  }
-  // printf("loaded index: %s\n", this->to_string().c_str());
-  return true;
+  return success;
 }
 
 void HakesIndex::UpdateIndex(const HakesIndex& update_index) {
@@ -102,53 +81,81 @@ void HakesIndex::UpdateIndex(const HakesIndex& update_index) {
     new_vt->is_trained = lt->is_trained;
     new_vts_.push_back(new_vt);
   }
-  // new ivf_vts
-  std::vector<VectorTransform*> new_ivf_vts_;
-  new_ivf_vts_.reserve(update_index.ivf_vts_.size());
-  for (auto vt : update_index.ivf_vts_) {
-    auto lt = dynamic_cast<LinearTransform*>(vt);
-    LinearTransform* new_vt = new LinearTransform(vt->d_in, vt->d_out);
-    new_vt->A = lt->A;
-    new_vt->b = lt->b;
-    new_vt->have_bias = lt->have_bias;
-    new_vt->is_trained = lt->is_trained;
-    new_ivf_vts_.push_back(new_vt);
+  // default behavior is to always install the updated index as query index
+  has_q_index_ = true;
+
+  if (has_q_index_) {
+    // clear old q_vts_
+    for (auto vt : q_vts_) {
+      delete vt;
+    }
+    q_vts_ = new_vts_;
+  } else {
+    // release the old ones
+    for (auto vt : vts_) {
+      delete vt;
+    }
+    vts_ = new_vts_;
   }
 
-  // new quantizer
-  IndexFlatL* new_quantizer =
-      new IndexFlatL(update_index.cq_->d, update_index.cq_->metric_type);
-  new_quantizer->ntotal = update_index.cq_->ntotal;
-  new_quantizer->is_trained = update_index.cq_->is_trained;
-  new_quantizer->codes = dynamic_cast<IndexFlatL*>(update_index.cq_)->codes;
+  // sq the update index ivf centroids
+  if (use_ivf_sq_) {
+    // apply sq to the update index ivf centroids
+    auto tmp = new IndexScalarQuantizerL(
+        update_index.base_index_->d,
+        ScalarQuantizer::QuantizerType::QT_8bit_direct,
+        faiss::MetricType::METRIC_L2);
+    int nlist = update_index.base_index_->quantizer->get_ntotal();
+    auto scaled_codes = std::vector<float>(nlist * update_index.base_index_->d);
+    const float* to_scale = (const float*)static_cast<IndexFlatL*>(
+                                update_index.base_index_->quantizer)
+                                ->codes.data();
+    for (int i = 0; i < nlist * update_index.base_index_->d; i++) {
+      scaled_codes[i] = to_scale[i] * 127 + 128;
+    }
+    tmp->add(nlist, scaled_codes.data());
+    if (has_q_index_) {
+      delete q_cq_;
+      q_cq_ = tmp;
+    } else {
+      delete cq_;
+      // install new ones
+      cq_ = tmp;
+    }
+  } else {
+    // new quantizer
+    IndexFlatL* new_quantizer =
+        new IndexFlatL(update_index.cq_->d, update_index.cq_->metric_type);
+    new_quantizer->ntotal = update_index.cq_->ntotal;
+    new_quantizer->is_trained = update_index.cq_->is_trained;
+    new_quantizer->codes = dynamic_cast<IndexFlatL*>(update_index.cq_)->codes;
+    if (has_q_index_) {
+      delete q_cq_;
+      q_cq_ = new_quantizer;
+    } else {
+      delete cq_;
+      // install new ones
+      base_index_->quantizer = new_quantizer;
+      cq_ = base_index_->quantizer;
+    }
+  }
 
   // new base index pq
   assert(update_index.base_index_->pq.M == base_index_->pq.M);
   assert(update_index.base_index_->pq.nbits == base_index_->pq.nbits);
-
-  // release the old ones
-  for (auto vt : vts_) {
-    delete vt;
+  if (has_q_index_) {
+    base_index_->has_q_pq = true;
+    base_index_->q_pq = update_index.base_index_->pq;
+  } else {
+    base_index_->pq.centroids = update_index.base_index_->pq.centroids;
   }
-  for (auto vt : ivf_vts_) {
-    delete vt;
-  }
-  delete cq_;
-  // install new ones
-  vts_ = new_vts_;
-  ivf_vts_ = new_ivf_vts_;
-  base_index_->quantizer = new_quantizer;
-  cq_ = base_index_->quantizer;
-  base_index_->pq.centroids = update_index.base_index_->pq.centroids;
-
-  share_vt_ = (cq_->d == base_index_->d);
 }
 
 bool HakesIndex::AddWithIds(int n, int d, const float* vecs,
                             const faiss::idx_t* xids, faiss::idx_t* assign,
                             int* vecs_t_d,
                             std::unique_ptr<float[]>* transformed_vecs) {
-  // auto start = std::chrono::high_resolution_clock::now();
+  auto start = std::chrono::high_resolution_clock::now();
 
   {
     // std::unique_lock lock(mapping_mu_);
@@ -158,7 +165,7 @@ bool HakesIndex::AddWithIds(int n, int d, const float* vecs,
     pthread_rwlock_unlock(&mapping_mu_);
   }
 
-  // auto refine_add_end = std::chrono::high_resolution_clock::now();
+  auto refine_add_end = std::chrono::high_resolution_clock::now();
 
   if (vts_.empty()) {
     base_index_->add_with_ids(n, vecs, xids, false, assign);
@@ -168,22 +175,6 @@ bool HakesIndex::AddWithIds(int n, int d, const float* vecs,
   // get assignment with cq first
   std::vector<float> vecs_t(n * d);
   bool assigned = false;
-  if (!ivf_vts_.empty()) {
-    std::memcpy(vecs_t.data(), vecs, n * d * sizeof(float));
-    std::vector<float> tmp;
-    for (auto vt : ivf_vts_) {
-      tmp.resize(n * vt->d_out);
-      std::memset(tmp.data(), 0, tmp.size() * sizeof(float));
-      vt->apply_noalloc(n, vecs_t.data(), tmp.data());
-      vecs_t.resize(tmp.size());
-      std::memcpy(vecs_t.data(), tmp.data(), tmp.size() * sizeof(float));
-    }
-    base_index_->get_add_assign(n, vecs_t.data(), assign);
-    assigned = true;
-  } else if (!share_vt_) {
-    base_index_->get_add_assign(n, vecs, assign);
-    assigned = true;
-  }
 
   vecs_t.resize(n * d);
   std::memcpy(vecs_t.data(), vecs, n * d * sizeof(float));
@@ -196,24 +187,32 @@ bool HakesIndex::AddWithIds(int n, int d, const float* vecs,
     std::memcpy(vecs_t.data(), tmp.data(), tmp.size() * sizeof(float));
   }
 
-  if (share_vt_) {
-    base_index_->get_add_assign(n, vecs_t.data(), assign);
-    assigned = true;
-  }
-
   // return the transformed vecs.
   *vecs_t_d = vecs_t.size() / n;
   transformed_vecs->reset(new float[vecs_t.size()]);
   std::memcpy(transformed_vecs->get(), vecs_t.data(),
               vecs_t.size() * sizeof(float));
 
-  // auto vt_add_end = std::chrono::high_resolution_clock::now();
+  auto vt_add_end = std::chrono::high_resolution_clock::now();
+  printf("transformed vecs\n");
+
+  base_index_->get_add_assign(n, vecs_t.data(), assign);
+  assigned = true;
+
+  auto cq_assign_end = std::chrono::high_resolution_clock::now();
+  printf("cq assigned\n");
 
   assert(vecs_t.size() == n * base_index_->d);
   // base_index_->add_with_ids(n, vecs_t.data(), xids, false, assign);
   base_index_->add_with_ids(n, vecs_t.data(), xids, assigned, assign);
 
-  // auto base_add_end = std::chrono::high_resolution_clock::now();
+  auto base_add_end = std::chrono::high_resolution_clock::now();
+
+  printf("refine add time: %f, vt add time: %f, cq assign time: %f, base add time: %f\n",
+         std::chrono::duration<double>(refine_add_end - start).count(),
+         std::chrono::duration<double>(vt_add_end - refine_add_end).count(),
+         std::chrono::duration<double>(cq_assign_end - vt_add_end).count(),
+         std::chrono::duration<double>(base_add_end - cq_assign_end).count());
   return true;
 }
 
@@ -229,22 +228,6 @@ bool HakesIndex::AddBase(int n, int d, const float* vecs,
   // get assignment with cq first
   std::vector<float> vecs_t(n * d);
   bool assigned = false;
-  if (!ivf_vts_.empty()) {
-    std::memcpy(vecs_t.data(), vecs, n * d * sizeof(float));
-    std::vector<float> tmp;
-    for (auto vt : ivf_vts_) {
-      tmp.resize(n * vt->d_out);
-      std::memset(tmp.data(), 0, tmp.size() * sizeof(float));
-      vt->apply_noalloc(n, vecs_t.data(), tmp.data());
-      vecs_t.resize(tmp.size());
-      std::memcpy(vecs_t.data(), tmp.data(), tmp.size() * sizeof(float));
-    }
-    base_index_->get_add_assign(n, vecs_t.data(), assign);
-    assigned = true;
-  } else if (!share_vt_) {
-    base_index_->get_add_assign(n, vecs, assign);
-    assigned = true;
-  }
 
   vecs_t.resize(n * d);
   std::memcpy(vecs_t.data(), vecs, n * d * sizeof(float));
@@ -257,10 +240,8 @@ bool HakesIndex::AddBase(int n, int d, const float* vecs,
     std::memcpy(vecs_t.data(), tmp.data(), tmp.size() * sizeof(float));
   }
 
-  if (share_vt_) {
-    base_index_->get_add_assign(n, vecs_t.data(), assign);
-    assigned = true;
-  }
+  base_index_->get_add_assign(n, vecs_t.data(), assign);
+  assigned = true;
 
   // auto vt_add_end = std::chrono::high_resolution_clock::now();
 
@@ -269,16 +250,6 @@ bool HakesIndex::AddBase(int n, int d, const float* vecs,
   base_index_->add_with_ids(n, vecs_t.data(), xids, assigned, assign);
 
   // auto base_add_end = std::chrono::high_resolution_clock::now();
-  return true;
-}
-
-bool HakesIndex::AddBasePreassigned(int n, int d, const float* vecs,
-                                    const faiss::idx_t* xids,
-                                    const faiss::idx_t* assign) {
-  assert(base_index_->d == d);
-
-  base_index_->add_with_ids(n, vecs, xids, true,
-                            const_cast<faiss::idx_t*>(assign));
   return true;
 }
 
@@ -302,11 +273,12 @@ bool HakesIndex::Search(int n, int d, const float* query,
   // std::chrono::duration<double> opq_alloc_time;
   // std::chrono::duration<double> opq_apply_time;
 
+  auto q_vts = has_q_index_ ? q_vts_ : vts_;
   std::vector<float> query_t(n * d);
   std::memcpy(query_t.data(), query, n * d * sizeof(float));
   {
     std::vector<float> tmp;
-    for (auto vt : vts_) {
+    for (auto vt : q_vts) {
       tmp.resize(n * vt->d_out);
       std::memset(tmp.data(), 0, tmp.size() * sizeof(float));
       // opq_alloc_time = std::chrono::high_resolution_clock::now() -
@@ -327,31 +299,10 @@ bool HakesIndex::Search(int n, int d, const float* query,
   std::unique_ptr<float[]> cq_dist =
       // std::make_unique<float[]>(params.nprobe * n);
       std::unique_ptr<float[]>(new float[params.nprobe * n]);
+  auto q_cq = has_q_index_ ? q_cq_ : cq_;
 
-  if (ivf_vts_.empty()) {
-    if (share_vt_) {
-      assert(cq_->d == query_t.size() / n);
-      cq_->search(n, query_t.data(), params.nprobe, cq_dist.get(),
-                  cq_ids.get());
-    } else {
-      // switch to just skip the ivf transform, we still assume that it is
-      // separated from the pq vt.
-      cq_->search(n, query, params.nprobe, cq_dist.get(), cq_ids.get());
-    }
-  } else {
-    std::vector<float> ivf_query_t(n * d);
-    std::vector<float> tmp;
-    std::memcpy(ivf_query_t.data(), query, n * d * sizeof(float));
-    for (auto vt : ivf_vts_) {
-      tmp.resize(n * vt->d_out);
-      std::memset(tmp.data(), 0, tmp.size() * sizeof(float));
-      vt->apply_noalloc(n, ivf_query_t.data(), tmp.data());
-      ivf_query_t.resize(tmp.size());
-      std::memcpy(ivf_query_t.data(), tmp.data(), tmp.size() * sizeof(float));
-    }
-    cq_->search(n, ivf_query_t.data(), params.nprobe, cq_dist.get(),
-                cq_ids.get());
-  }
+  assert(q_cq->d == query_t.size() / n);
+  q_cq->search(n, query_t.data(), params.nprobe, cq_dist.get(), cq_ids.get());
   // auto cq_end = std::chrono::high_resolution_clock::now();
 
   // step 2: search the base index
@@ -360,9 +311,12 @@ bool HakesIndex::Search(int n, int d, const float* query,
   std::unique_ptr<float[]> base_dist(new float[n * k_base]);
   faiss::IVFSearchParameters base_params;
   base_params.nprobe = params.nprobe;
-  base_index_->search_preassigned(n, query_t.data(), k_base, cq_ids.get(),
-                                  cq_dist.get(), base_dist.get(),
-                                  base_lab.get(), false, &base_params);
+  for (int i = 0; i < n; i++) {
+    base_index_->search_preassigned_new(
+        1, query_t.data() + i * d, k_base, cq_ids.get() + i * params.nprobe,
+        cq_dist.get() + i * params.nprobe, base_dist.get() + i * k_base,
+        base_lab.get() + i * k_base, false, &base_params);
+  }
 
   // step 3: return the base search results
   distances->reset(base_dist.release());
@@ -461,18 +415,30 @@ bool HakesIndex::Rerank(int n, int d, const float* query, int k,
 }
 
 // same as EngineV2
-bool HakesIndex::Checkpoint(IOWriter* f) {
+bool HakesIndex::Checkpoint(hakes::IOWriter* f) {
   return write_hakes_index_single_file(f, this);
+}
+
+std::string HakesIndex::GetParams() const {
+  hakes::StringIOWriter w;
+  bool success = write_hakes_index_single_file(&w, this);
+  return success ? w.data : "";
+}
+
+bool HakesIndex::UpdateParams(const std::string& params) {
+  hakes::StringIOReader r(params.data(), params.size());
+  HakesIndex loaded;
+  bool success = load_hakes_index_single_file(&r, &loaded);
+  if (!success) {
+    return false;
+  }
+  UpdateIndex(loaded);
+  return true;
 }
 
 std::string HakesIndex::to_string() const {
   std::string ret = "HakesIndex:\nopq vt size " + std::to_string(vts_.size());
   for (auto vt : vts_) {
-    ret += "\n  d_in " + std::to_string(vt->d_in) + ", d_out " +
-           std::to_string(vt->d_out);
-  }
-  ret = ret + "\nivf vt size " + std::to_string(ivf_vts_.size());
-  for (auto vt : ivf_vts_) {
     ret += "\n  d_in " + std::to_string(vt->d_in) + ", d_out " +
            std::to_string(vt->d_out);
   }

--- a/search-worker/index/ext/HakesIndex.h
+++ b/search-worker/index/ext/HakesIndex.h
@@ -37,9 +37,19 @@ class HakesIndex {
   ~HakesIndex() {
     for (auto vt : vts_) {
       delete vt;
+      vt = nullptr;
     }
-    for (auto vt : ivf_vts_) {
+    for (auto vt : q_vts_) {
       delete vt;
+      vt = nullptr;
+    }
+    if (use_ivf_sq_) {
+      delete cq_;
+      cq_ = nullptr;
+    }
+    if (q_cq_) {
+      delete q_cq_;
+      q_cq_ = nullptr;
     }
   }
 
@@ -51,16 +61,9 @@ class HakesIndex {
   HakesIndex& operator=(HakesIndex&&) = delete;
 
   // bool Initialize(const std::string& path);
-  bool Initialize(IOReader* f, bool params_only = true);
+  bool Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf, bool keep_pa = false);
 
   void UpdateIndex(const HakesIndex& other);
-
-  bool AddWithIds(int n, int d, const float* vecs, const faiss::idx_t* ids) {
-    // printf(
-    //     "EngineV3::AddWithIds need to return results of base index "
-    //     "assignment\n");
-    return false;
-  }
 
   // it is assumed that receiving engine shall store the full vecs of all
   // inputs.
@@ -69,9 +72,6 @@ class HakesIndex {
                   std::unique_ptr<float[]>* vecs_t);
 
   bool AddBase(int n, int d, const float* vecs, const faiss::idx_t* ids);
-
-  bool AddBasePreassigned(int n, int d, const float* vecs,
-                          const faiss::idx_t* ids, const faiss::idx_t* assign);
 
   bool Search(int n, int d, const float* query, const HakesSearchParams& params,
               std::unique_ptr<float[]>* distances,
@@ -82,23 +82,31 @@ class HakesIndex {
               float* base_distances, std::unique_ptr<float[]>* distances,
               std::unique_ptr<faiss::idx_t[]>* labels);
 
-  inline bool has_ivf_vts() const { return ivf_vts_.size() > 0; }
+  bool Checkpoint(hakes::IOWriter* f);
 
-  bool Checkpoint(IOWriter* f);
+  std::string GetParams() const;
+
+  bool UpdateParams(const std::string& params);
 
   std::string to_string() const;
 
   //  private:
  public:
   std::string index_path_;
-  bool share_vt_;
+  bool use_ivf_sq_ = false;
+  bool use_refine_sq_ = false;
   std::vector<faiss::VectorTransform*> vts_;
-  std::vector<faiss::VectorTransform*> ivf_vts_;
-  faiss::Index* cq_;
+  bool has_q_index_ = false;
+  std::vector<faiss::VectorTransform*> q_vts_;
+  faiss::Index* cq_ = nullptr;
+  faiss::Index* q_cq_ = nullptr;
   std::unique_ptr<faiss::IndexIVFPQFastScanL> base_index_;
   mutable pthread_rwlock_t mapping_mu_;
   std::unique_ptr<faiss::IDMap> mapping_;
   std::unique_ptr<faiss::IndexFlatL> refine_index_;
+
+  bool keep_pa_ = false;
+  std::unordered_map<faiss::idx_t, faiss::idx_t> pa_mapping_;
 };
 
 }  // namespace faiss

--- a/search-worker/index/ext/HakesIndex.h
+++ b/search-worker/index/ext/HakesIndex.h
@@ -33,7 +33,7 @@ struct HakesSearchParams {
 
 class HakesIndex {
  public:
-  HakesIndex() = default;
+  HakesIndex() { pthread_rwlock_init(&mapping_mu_, nullptr); }
   ~HakesIndex() {
     for (auto vt : vts_) {
       delete vt;
@@ -51,6 +51,7 @@ class HakesIndex {
       delete q_cq_;
       q_cq_ = nullptr;
     }
+    pthread_rwlock_destroy(&mapping_mu_);
   }
 
   // delete copy constructors and assignment operators
@@ -61,7 +62,8 @@ class HakesIndex {
   HakesIndex& operator=(HakesIndex&&) = delete;
 
   // bool Initialize(const std::string& path);
-  bool Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf, bool keep_pa = false);
+  bool Initialize(hakes::IOReader* ff, hakes::IOReader* rf, hakes::IOReader* uf,
+                  bool keep_pa = false);
 
   void UpdateIndex(const HakesIndex& other);
 
@@ -82,11 +84,11 @@ class HakesIndex {
               float* base_distances, std::unique_ptr<float[]>* distances,
               std::unique_ptr<faiss::idx_t[]>* labels);
 
-  bool Checkpoint(hakes::IOWriter* f);
+  bool Checkpoint(hakes::IOWriter* ff, hakes::IOWriter* rf) const;
 
-  std::string GetParams() const;
+  bool GetParams(hakes::IOWriter* pf) const;
 
-  bool UpdateParams(const std::string& params);
+  bool UpdateParams(hakes::IOReader* pf);
 
   std::string to_string() const;
 

--- a/search-worker/index/ext/IdMap.cpp
+++ b/search-worker/index/ext/IdMap.cpp
@@ -65,14 +65,14 @@ bool IDMapImpl::reset() {
 
 namespace {
 
-void write_map(const std::unordered_map<idx_t, idx_t>& m, IOWriter* f) {
+void write_map(const std::unordered_map<idx_t, idx_t>& m, hakes::IOWriter* f) {
   std::vector<std::pair<idx_t, idx_t>> v;
   v.resize(m.size());
   std::copy(m.begin(), m.end(), v.begin());
   WRITEVECTOR(v);
 }
 
-void read_map(std::unordered_map<idx_t, idx_t>* m, IOReader* f) {
+void read_map(std::unordered_map<idx_t, idx_t>* m, hakes::IOReader* f) {
   std::vector<std::pair<idx_t, idx_t>> v;
   READVECTOR(v);
   m->clear();
@@ -84,14 +84,14 @@ void read_map(std::unordered_map<idx_t, idx_t>* m, IOReader* f) {
 
 }  // anonymous namespace
 
-bool IDMapImpl::load(IOReader* f, int io_flags) {
+bool IDMapImpl::load(hakes::IOReader* f, int io_flags) {
   read_map(&off_to_idx_, f);
   read_map(&idx_to_off_, f);
   ntotal_ = off_to_idx_.size();
   return true;
 }
 
-bool IDMapImpl::save(IOWriter* f) const {
+bool IDMapImpl::save(hakes::IOWriter* f) const {
   write_map(off_to_idx_, f);
   write_map(idx_to_off_, f);
   return true;

--- a/search-worker/index/ext/IdMap.h
+++ b/search-worker/index/ext/IdMap.h
@@ -19,9 +19,10 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include "search-worker/index/MetricType.h"
-#include "search-worker/index/impl/io.h"
+#include "utils/io.h"
 
 namespace faiss {
 
@@ -44,9 +45,9 @@ class IDMap {
 
   virtual bool reset() = 0;
 
-  virtual bool load(IOReader* f, int io_flags = 0) = 0;
+  virtual bool load(hakes::IOReader* f, int io_flags = 0) = 0;
 
-  virtual bool save(IOWriter* f) const = 0;
+  virtual bool save(hakes::IOWriter* f) const = 0;
 
   virtual std::string to_string() const { return "IDMap"; };
 };
@@ -73,8 +74,8 @@ class IDMapImpl : public IDMap {
 
   bool reset() override;
 
-  bool load(IOReader* f, int io_flags = 0) override;
-  bool save(IOWriter* f) const override;
+  bool load(hakes::IOReader* f, int io_flags = 0) override;
+  bool save(hakes::IOWriter* f) const override;
 
   std::string to_string() const override;
 

--- a/search-worker/index/ext/IndexFlatCodesL.cpp
+++ b/search-worker/index/ext/IndexFlatCodesL.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstring>
+#include <typeinfo>
 
 #include "search-worker/index/impl/CodePacker.h"
 

--- a/search-worker/index/ext/IndexFlatCodesL.h
+++ b/search-worker/index/ext/IndexFlatCodesL.h
@@ -112,6 +112,10 @@ struct IndexFlatCodesL : Index {
 
   // permute_entries. perm of size ntotal maps new to old positions
   void permute_entries(const idx_t* perm);
+
+  virtual void compute_distance_subset(
+      idx_t n, const float* x, idx_t k, float* distances, const idx_t* labels,
+      const SearchParameters* params = nullptr) const = 0;
 };
 
 }  // namespace faiss

--- a/search-worker/index/ext/IndexFlatL.cpp
+++ b/search-worker/index/ext/IndexFlatL.cpp
@@ -89,8 +89,8 @@ void IndexFlatL::range_search(idx_t n, const float* x, float radius,
 }
 
 void IndexFlatL::compute_distance_subset(idx_t n, const float* x, idx_t k,
-                                         float* distances,
-                                         const idx_t* labels) const {
+                                         float* distances, const idx_t* labels,
+                                         const SearchParameters* params) const {
   // obtain the shared access here so ntotal can be directly accessed
   const float* xb = get_xb();
   switch (metric_type) {

--- a/search-worker/index/ext/IndexFlatL.h
+++ b/search-worker/index/ext/IndexFlatL.h
@@ -53,7 +53,7 @@ struct IndexFlatL : IndexFlatCodesL {
    *                corresponding output distances, size n * k
    */
   void compute_distance_subset(idx_t n, const float* x, idx_t k,
-                               float* distances, const idx_t* labels) const;
+                               float* distances, const idx_t* labels, const SearchParameters* params = nullptr) const;
 
   // it will obtain shared lock, so call release_xb() after use
   const float* get_xb() const {

--- a/search-worker/index/ext/IndexIVFL.cpp
+++ b/search-worker/index/ext/IndexIVFL.cpp
@@ -179,6 +179,7 @@ IndexIVFL::IndexIVFL(Index* quantizer, size_t d, size_t nlist, size_t code_size,
   if (metric_type == METRIC_INNER_PRODUCT) {
     cp.spherical = true;
   }
+  pthread_rwlock_init(&mu_, nullptr);
 }
 
 // IndexIVFL::IndexIVFL() = default;
@@ -1194,6 +1195,7 @@ IndexIVFL::~IndexIVFL() {
   if (own_invlists) {
     delete invlists;
   }
+  pthread_rwlock_destroy(&this->mu_);
 }
 
 /*************************************************************************

--- a/search-worker/index/ext/IndexIVFL.h
+++ b/search-worker/index/ext/IndexIVFL.h
@@ -92,12 +92,20 @@ struct IndexIVFL : Index, IndexIVFInterface {
   // mutable std::shared_mutex mu_;
   mutable pthread_rwlock_t mu_;
 
+  IndexIVFL() { pthread_rwlock_init(&mu_, nullptr); }
+
   /** The Inverted file takes a quantizer (an Index) on input,
    * which implements the function mapping a vector to a list
    * identifier.
    */
   IndexIVFL(Index* quantizer, size_t d, size_t nlist, size_t code_size,
             MetricType metric = METRIC_L2);
+
+  // delete copy and move constructor and assign operators
+  IndexIVFL(const IndexIVFL&) = delete;
+  IndexIVFL& operator=(const IndexIVFL&) = delete;
+  IndexIVFL(IndexIVFL&&) = delete;
+  IndexIVFL& operator=(IndexIVFL&&) = delete;
 
   idx_t get_nTotal() const {
     // std::shared_lock lock(mu_);
@@ -296,8 +304,6 @@ struct IndexIVFL : Index, IndexIVFInterface {
   /* The standalone codec interface (except sa_decode that is specific) */
   size_t sa_code_size() const override;
   void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
-
-  IndexIVFL() = default;
 };
 
 struct IndexIVFStatsL {
@@ -311,7 +317,19 @@ struct IndexIVFStatsL {
   // std::shared_mutex mu_;
   mutable pthread_rwlock_t mu_;
 
-  IndexIVFStatsL() { reset(); }
+  IndexIVFStatsL() {
+    pthread_rwlock_init(&mu_, nullptr);
+    reset();
+  }
+
+  ~IndexIVFStatsL() { pthread_rwlock_destroy(&mu_); }
+
+  // delete copy and move constructor and assign operators
+  IndexIVFStatsL(const IndexIVFStatsL&) = delete;
+  IndexIVFStatsL& operator=(const IndexIVFStatsL&) = delete;
+  IndexIVFStatsL(IndexIVFStatsL&&) = delete;
+  IndexIVFStatsL& operator=(IndexIVFStatsL&&) = delete;
+
   void reset();
   // void add(const IndexIVFStats& other);
 };

--- a/search-worker/index/ext/IndexIVFPQFastScanL.h
+++ b/search-worker/index/ext/IndexIVFPQFastScanL.h
@@ -51,6 +51,8 @@ namespace faiss {
 
 struct IndexIVFPQFastScanL : IndexIVFFastScanL {
   ProductQuantizer pq;  ///< produces the codes
+  bool has_q_pq = false;
+  ProductQuantizer q_pq;  ///< produces the query codes
 
   /// precomputed tables management
   int use_precomputed_table = 0;

--- a/search-worker/index/ext/IndexRefineL.cpp
+++ b/search-worker/index/ext/IndexRefineL.cpp
@@ -50,6 +50,7 @@ IndexRefineL::IndexRefineL(Index* base_index, Index* refine_index)
     assert(base_index->get_ntotal() == refine_index->get_ntotal());
   }  // other case is useful only to construct an IndexRefineFlatL
   ntotal = base_index->get_ntotal();
+  pthread_rwlock_init(&mu, nullptr);
 }
 
 void IndexRefineL::train(idx_t n, const float* x) {
@@ -241,6 +242,7 @@ void IndexRefineL::sa_decode(idx_t n, const uint8_t* bytes, float* x) const {
 IndexRefineL::~IndexRefineL() {
   if (own_fields) delete base_index;
   if (own_refine_index) delete refine_index;
+  pthread_rwlock_destroy(&mu);
 }
 
 /***************************************************

--- a/search-worker/index/ext/IndexRefineL.h
+++ b/search-worker/index/ext/IndexRefineL.h
@@ -86,48 +86,15 @@ struct IndexRefineL : Index {
       : base_index(nullptr),
         refine_index(nullptr),
         own_fields(false),
-        own_refine_index(false) {}
+        own_refine_index(false) {
+    pthread_rwlock_init(&mu, nullptr);
+  }
 
-  // copy constructors
-  IndexRefineL(const IndexRefineL& other) : Index() {
-    // index fields
-    d = other.d;
-    ntotal = other.ntotal;
-    verbose = other.verbose;
-    is_trained = other.is_trained;
-    metric_type = other.metric_type;
-    metric_arg = other.metric_arg;
-    // IndexRefineL fields
-    base_index = other.base_index;
-    refine_index = other.refine_index;
-    own_fields = other.own_fields;
-    own_refine_index = other.own_refine_index;
-    k_factor = other.k_factor;
-    idx_to_off = other.idx_to_off;
-    off_to_idx = other.off_to_idx;
-  };
-  // copy assignment operator
-  IndexRefineL& operator=(const IndexRefineL& other) {
-    if (this == &other) {
-      return *this;
-    }
-    // index fields
-    d = other.d;
-    ntotal = other.ntotal;
-    verbose = other.verbose;
-    is_trained = other.is_trained;
-    metric_type = other.metric_type;
-    metric_arg = other.metric_arg;
-    // IndexRefineL fields
-    base_index = other.base_index;
-    refine_index = other.refine_index;
-    own_fields = other.own_fields;
-    own_refine_index = other.own_refine_index;
-    k_factor = other.k_factor;
-    idx_to_off = other.idx_to_off;
-    off_to_idx = other.off_to_idx;
-    return *this;
-  };
+  // delete copy and move constructor and assign operators
+  IndexRefineL(const IndexRefineL&) = delete;
+  IndexRefineL& operator=(const IndexRefineL&) = delete;
+  IndexRefineL(IndexRefineL&&) = delete;
+  IndexRefineL& operator=(IndexRefineL&&) = delete;
 
   void train(idx_t n, const float* x) override;
 

--- a/search-worker/index/ext/IndexScalarQuantizerL.cpp
+++ b/search-worker/index/ext/IndexScalarQuantizerL.cpp
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+// #include <faiss/ext/IndexScalarQuantizerL.h>
+#include <search-worker/index/ext/IndexScalarQuantizerL.h>
+// #include <faiss/impl/AuxIndexStructures.h>
+// #include <faiss/impl/FaissAssert.h>
+// #include <faiss/impl/IDSelector.h>
+// #include <faiss/impl/ScalarQuantizer.h>
+// #include <faiss/utils/utils.h>
+#include <omp.h>
+
+#include <algorithm>
+#include <cstdio>
+
+namespace faiss {
+
+/*******************************************************************
+ * IndexScalarQuantizerL implementation
+ ********************************************************************/
+
+IndexScalarQuantizerL::IndexScalarQuantizerL(
+    int d, ScalarQuantizer::QuantizerType qtype, MetricType metric)
+    : IndexFlatCodesL(0, d, metric), sq(d, qtype) {
+  is_trained = qtype == ScalarQuantizer::QT_fp16 ||
+               qtype == ScalarQuantizer::QT_8bit_direct;
+  code_size = sq.code_size;
+}
+
+IndexScalarQuantizerL::IndexScalarQuantizerL()
+    : IndexScalarQuantizerL(0, ScalarQuantizer::QT_8bit) {}
+
+void IndexScalarQuantizerL::train(idx_t n, const float* x) {
+  sq.train(n, x);
+  is_trained = true;
+}
+
+void IndexScalarQuantizerL::search(idx_t n, const float* x, idx_t k,
+                                   float* distances, idx_t* labels,
+                                   const SearchParameters* params) const {
+  const uint8_t* xb = get_xb();
+  const IDSelector* sel = params ? params->sel : nullptr;
+
+  // FAISS_THROW_IF_NOT(k > 0);
+  // FAISS_THROW_IF_NOT(is_trained);
+  // FAISS_THROW_IF_NOT(metric_type == METRIC_L2 ||
+  //                    metric_type == METRIC_INNER_PRODUCT);
+  assert(k > 0);
+  assert(is_trained);
+  assert(metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
+
+  // #pragma omp parallel
+  {
+    std::unique_ptr<InvertedListScanner> scanner(
+        sq.select_InvertedListScanner(metric_type, nullptr, true, sel));
+
+    scanner->list_no = 0;  // directly the list number
+
+    // #pragma omp for
+    for (idx_t i = 0; i < n; i++) {
+      float* D = distances + k * i;
+      idx_t* I = labels + k * i;
+      // re-order heap
+      if (metric_type == METRIC_L2) {
+        maxheap_heapify(k, D, I);
+      } else {
+        minheap_heapify(k, D, I);
+      }
+      //   for (int j = 0; j < k; ++j) {
+      //     printf(" %ld (%.4f)", I[j], D[j]);
+      //   }
+      //   auto scan_start_time = std::chrono::high_resolution_clock::now();
+      scanner->set_query(x + i * d);
+      scanner->scan_codes(ntotal, xb, nullptr, D, I, k);
+      //   auto scan_end_time = std::chrono::high_resolution_clock::now();
+
+      //   auto heap_start_time = std::chrono::high_resolution_clock::now();
+      // re-order heap
+      if (metric_type == METRIC_L2) {
+        maxheap_reorder(k, D, I);
+      } else {
+        minheap_reorder(k, D, I);
+      }
+      //   for (int j = 0; j < k; ++j) {
+      //     printf(" %ld (%.4f)", I[j], D[j]);
+      //   }
+      //   auto heap_end_time = std::chrono::high_resolution_clock::now();
+      //   if (print_stats) {
+      //     printf("scan time: %.6f, heap time: %.6f\n",
+      //            std::chrono::duration<double>(scan_end_time -
+      //            scan_start_time)
+      //                .count(),
+      //            std::chrono::duration<double>(heap_end_time -
+      //            heap_start_time)
+      //                .count());
+      //   }
+    }
+  }
+}
+
+// FlatCodesDistanceComputer*
+// IndexScalarQuantizerL::get_FlatCodesDistanceComputer()
+//         const {
+//     ScalarQuantizer::SQDistanceComputer* dc =
+//             sq.get_distance_computer(metric_type);
+//     dc->code_size = sq.code_size;
+//     dc->codes = codes.data();
+//     return dc;
+// }
+
+/* Codec interface */
+
+void IndexScalarQuantizerL::sa_encode(idx_t n, const float* x,
+                                      uint8_t* bytes) const {
+  // FAISS_THROW_IF_NOT(is_trained);
+  assert(is_trained);
+  sq.compute_codes(x, bytes, n);
+}
+
+void IndexScalarQuantizerL::sa_decode(idx_t n, const uint8_t* bytes,
+                                      float* x) const {
+  // FAISS_THROW_IF_NOT(is_trained);
+  assert(is_trained);
+  sq.decode(bytes, x, n);
+}
+
+void IndexScalarQuantizerL::compute_distance_subset(
+    idx_t n, const float* x, idx_t k, float* distances, const idx_t* labels,
+    const SearchParameters* params) const {
+  const IDSelector* sel = params ? params->sel : nullptr;
+
+  // FAISS_THROW_IF_NOT(k > 0);
+  // FAISS_THROW_IF_NOT(is_trained);
+  // FAISS_THROW_IF_NOT(metric_type == METRIC_L2 ||
+  //                    metric_type == METRIC_INNER_PRODUCT);
+  assert(k > 0);
+  assert(is_trained);
+  assert(metric_type == METRIC_L2 || metric_type == METRIC_INNER_PRODUCT);
+
+  std::unique_ptr<InvertedListScanner> scanner(
+      sq.select_InvertedListScanner(metric_type, nullptr, true, sel));
+  scanner->set_query(x);
+  //   auto code_size = scanner->code_size;
+
+  const uint8_t* xb = get_xb();
+  for (idx_t i = 0; i < k; i++) {
+    if (labels[i] < 0) {
+      break;
+    }
+    distances[i] = scanner->distance_to_code(xb + labels[i] * code_size);
+  }
+  release_xb();
+}
+
+// /*******************************************************************
+//  * IndexIVFScalarQuantizer implementation
+//  ********************************************************************/
+
+// IndexIVFScalarQuantizer::IndexIVFScalarQuantizer(
+//         Index* quantizer,
+//         size_t d,
+//         size_t nlist,
+//         ScalarQuantizer::QuantizerType qtype,
+//         MetricType metric,
+//         bool by_residual)
+//         : IndexIVF(quantizer, d, nlist, 0, metric), sq(d, qtype) {
+//     code_size = sq.code_size;
+//     this->by_residual = by_residual;
+//     // was not known at construction time
+//     invlists->code_size = code_size;
+//     is_trained = false;
+// }
+
+// IndexIVFScalarQuantizer::IndexIVFScalarQuantizer() : IndexIVF() {
+//     by_residual = true;
+// }
+
+// void IndexIVFScalarQuantizer::train_encoder(
+//         idx_t n,
+//         const float* x,
+//         const idx_t* assign) {
+//     sq.train(n, x);
+// }
+
+// idx_t IndexIVFScalarQuantizer::train_encoder_num_vectors() const {
+//     return 100000;
+// }
+
+// void IndexIVFScalarQuantizer::encode_vectors(
+//         idx_t n,
+//         const float* x,
+//         const idx_t* list_nos,
+//         uint8_t* codes,
+//         bool include_listnos) const {
+//     std::unique_ptr<ScalarQuantizer::SQuantizer>
+//     squant(sq.select_quantizer()); size_t coarse_size = include_listnos ?
+//     coarse_code_size() : 0; memset(codes, 0, (code_size + coarse_size) * n);
+
+// #pragma omp parallel if (n > 1000)
+//     {
+//         std::vector<float> residual(d);
+
+// #pragma omp for
+//         for (idx_t i = 0; i < n; i++) {
+//             int64_t list_no = list_nos[i];
+//             if (list_no >= 0) {
+//                 const float* xi = x + i * d;
+//                 uint8_t* code = codes + i * (code_size + coarse_size);
+//                 if (by_residual) {
+//                     quantizer->compute_residual(xi, residual.data(),
+//                     list_no); xi = residual.data();
+//                 }
+//                 if (coarse_size) {
+//                     encode_listno(list_no, code);
+//                 }
+//                 squant->encode_vector(xi, code + coarse_size);
+//             }
+//         }
+//     }
+// }
+
+// void IndexIVFScalarQuantizer::sa_decode(idx_t n, const uint8_t* codes, float*
+// x)
+//         const {
+//     std::unique_ptr<ScalarQuantizer::SQuantizer>
+//     squant(sq.select_quantizer()); size_t coarse_size = coarse_code_size();
+
+// #pragma omp parallel if (n > 1000)
+//     {
+//         std::vector<float> residual(d);
+
+// #pragma omp for
+//         for (idx_t i = 0; i < n; i++) {
+//             const uint8_t* code = codes + i * (code_size + coarse_size);
+//             int64_t list_no = decode_listno(code);
+//             float* xi = x + i * d;
+//             squant->decode_vector(code + coarse_size, xi);
+//             if (by_residual) {
+//                 quantizer->reconstruct(list_no, residual.data());
+//                 for (size_t j = 0; j < d; j++) {
+//                     xi[j] += residual[j];
+//                 }
+//             }
+//         }
+//     }
+// }
+
+// void IndexIVFScalarQuantizer::add_core(
+//         idx_t n,
+//         const float* x,
+//         const idx_t* xids,
+//         const idx_t* coarse_idx) {
+//     FAISS_THROW_IF_NOT(is_trained);
+
+//     size_t nadd = 0;
+//     std::unique_ptr<ScalarQuantizer::SQuantizer>
+//     squant(sq.select_quantizer());
+
+//     DirectMapAdd dm_add(direct_map, n, xids);
+
+// #pragma omp parallel reduction(+ : nadd)
+//     {
+//         std::vector<float> residual(d);
+//         std::vector<uint8_t> one_code(code_size);
+//         int nt = omp_get_num_threads();
+//         int rank = omp_get_thread_num();
+
+//         // each thread takes care of a subset of lists
+//         for (size_t i = 0; i < n; i++) {
+//             int64_t list_no = coarse_idx[i];
+//             if (list_no >= 0 && list_no % nt == rank) {
+//                 int64_t id = xids ? xids[i] : ntotal + i;
+
+//                 const float* xi = x + i * d;
+//                 if (by_residual) {
+//                     quantizer->compute_residual(xi, residual.data(),
+//                     list_no); xi = residual.data();
+//                 }
+
+//                 memset(one_code.data(), 0, code_size);
+//                 squant->encode_vector(xi, one_code.data());
+
+//                 size_t ofs = invlists->add_entry(list_no, id,
+//                 one_code.data());
+
+//                 dm_add.add(i, list_no, ofs);
+//                 nadd++;
+
+//             } else if (rank == 0 && list_no == -1) {
+//                 dm_add.add(i, -1, 0);
+//             }
+//         }
+//     }
+
+//     ntotal += n;
+// }
+
+// InvertedListScanner* IndexIVFScalarQuantizer::get_InvertedListScanner(
+//         bool store_pairs,
+//         const IDSelector* sel) const {
+//     return sq.select_InvertedListScanner(
+//             metric_type, quantizer, store_pairs, sel, by_residual);
+// }
+
+// void IndexIVFScalarQuantizer::reconstruct_from_offset(
+//         int64_t list_no,
+//         int64_t offset,
+//         float* recons) const {
+//     const uint8_t* code = invlists->get_single_code(list_no, offset);
+
+//     if (by_residual) {
+//         std::vector<float> centroid(d);
+//         quantizer->reconstruct(list_no, centroid.data());
+
+//         sq.decode(code, recons, 1);
+//         for (int i = 0; i < d; ++i) {
+//             recons[i] += centroid[i];
+//         }
+//     } else {
+//         sq.decode(code, recons, 1);
+//     }
+// }
+
+}  // namespace faiss

--- a/search-worker/index/ext/IndexScalarQuantizerL.h
+++ b/search-worker/index/ext/IndexScalarQuantizerL.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#ifndef FAISS_INDEX_SCALAR_QUANTIZER_H
+#define FAISS_INDEX_SCALAR_QUANTIZER_H
+
+// #include <faiss/IndexFlatCodes.h>
+#include <search-worker/index/IndexFlatCodes.h>
+// #include <faiss/IndexIVF.h>
+#include <search-worker/index/IndexIVF.h>
+// #include <faiss/ext/IndexFlatCodesL.h>
+#include <search-worker/index/ext/IndexFlatCodesL.h>
+// #include <faiss/impl/ScalarQuantizer.h>
+#include <search-worker/index/impl/ScalarQuantizer.h>
+#include <stdint.h>
+
+#include <vector>
+
+namespace faiss {
+
+/**
+ * Flat index built on a scalar quantizer.
+ */
+struct IndexScalarQuantizerL : IndexFlatCodesL {
+  /// Used to encode the vectors
+  ScalarQuantizer sq;
+
+  /** Constructor.
+   *
+   * @param d      dimensionality of the input vectors
+   * @param M      number of subquantizers
+   * @param nbits  number of bit per subvector index
+   */
+  IndexScalarQuantizerL(int d, ScalarQuantizer::QuantizerType qtype,
+                        MetricType metric = METRIC_L2);
+
+  IndexScalarQuantizerL();
+
+  void train(idx_t n, const float* x) override;
+
+  void search(idx_t n, const float* x, idx_t k, float* distances, idx_t* labels,
+              const SearchParameters* params = nullptr) const override;
+
+  //   FlatCodesDistanceComputer* get_FlatCodesDistanceComputer() const
+  //   override;
+
+  // it will obtain shared lock, so call release_xb() after use
+  const uint8_t* get_xb() const {
+    // this->codes_mutex.lock_shared();
+    pthread_rwlock_rdlock(&this->codes_mutex);
+    return codes.data();
+  }
+
+  // void release_xb() const { this->codes_mutex.unlock_shared(); }
+  void release_xb() const { pthread_rwlock_unlock(&this->codes_mutex); }
+
+  /* standalone codec interface */
+  void sa_encode(idx_t n, const float* x, uint8_t* bytes) const override;
+
+  void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+
+  void compute_distance_subset(
+      idx_t n, const float* x, idx_t k, float* distances, const idx_t* labels,
+      const SearchParameters* params = nullptr) const override;
+};
+
+// /** An IVF implementation where the components of the residuals are
+//  * encoded with a scalar quantizer. All distance computations
+//  * are asymmetric, so the encoded vectors are decoded and approximate
+//  * distances are computed.
+//  */
+
+// struct IndexIVFScalarQuantizer : IndexIVF {
+//     ScalarQuantizer sq;
+
+//     IndexIVFScalarQuantizer(
+//             Index* quantizer,
+//             size_t d,
+//             size_t nlist,
+//             ScalarQuantizer::QuantizerType qtype,
+//             MetricType metric = METRIC_L2,
+//             bool by_residual = true);
+
+//     IndexIVFScalarQuantizer();
+
+//     void train_encoder(idx_t n, const float* x, const idx_t* assign)
+//     override;
+
+//     idx_t train_encoder_num_vectors() const override;
+
+//     void encode_vectors(
+//             idx_t n,
+//             const float* x,
+//             const idx_t* list_nos,
+//             uint8_t* codes,
+//             bool include_listnos = false) const override;
+
+//     void add_core(
+//             idx_t n,
+//             const float* x,
+//             const idx_t* xids,
+//             const idx_t* precomputed_idx) override;
+
+//     InvertedListScanner* get_InvertedListScanner(
+//             bool store_pairs,
+//             const IDSelector* sel) const override;
+
+//     void reconstruct_from_offset(int64_t list_no, int64_t offset, float*
+//     recons)
+//             const override;
+
+//     /* standalone codec interface */
+//     void sa_decode(idx_t n, const uint8_t* bytes, float* x) const override;
+// };
+
+}  // namespace faiss
+
+#endif

--- a/search-worker/index/ext/index_io_ext.cpp
+++ b/search-worker/index/ext/index_io_ext.cpp
@@ -32,390 +32,6 @@ namespace faiss {
  * streamlined functions from index_read.cpp and index_write.cpp
  */
 
-namespace {
-
-void read_index_header(Index* idx, hakes::IOReader* f) {
-  READ1(idx->d);
-  READ1(idx->ntotal);
-  idx_t dummy;
-  READ1(dummy);
-  READ1(dummy);
-  READ1(idx->is_trained);
-  READ1(idx->metric_type);
-  if (idx->metric_type > 1) {
-    READ1(idx->metric_arg);
-  }
-  idx->verbose = false;
-}
-
-static void read_ArrayInvertedLists_sizes(hakes::IOReader* f,
-                                          std::vector<size_t>& sizes) {
-  uint32_t list_type;
-  READ1(list_type);
-  if (list_type == fourcc("full")) {
-    size_t os = sizes.size();
-    READVECTOR(sizes);
-    // FAISS_THROW_IF_NOT(os == sizes.size());
-    assert(os == sizes.size());
-  } else if (list_type == fourcc("sprs")) {
-    std::vector<size_t> idsizes;
-    READVECTOR(idsizes);
-    for (size_t j = 0; j < idsizes.size(); j += 2) {
-      // FAISS_THROW_IF_NOT(idsizes[j] < sizes.size());
-      assert(idsizes[j] < sizes.size());
-      sizes[idsizes[j]] = idsizes[j + 1];
-    }
-  } else {
-    // FAISS_THROW_FMT(
-    //         "list_type %ud (\"%s\") not recognized",
-    //         list_type,
-    //         fourcc_inv_printable(list_type).c_str());
-    assert(!"list_type not recognized");
-  }
-}
-
-InvertedLists* read_BlockInvertedLists(hakes::IOReader* f) {
-  size_t nlist, code_size, n_per_block, block_size;
-  std::vector<int> load_list;
-  READ1(nlist);
-  READ1(code_size);
-  READ1(n_per_block);
-  READ1(block_size);
-  READVECTOR(load_list);
-
-  BlockInvertedListsL* il =
-      new BlockInvertedListsL(nlist, n_per_block, block_size);
-
-  for (size_t i = 0; i < il->nlist; i++) {
-    il->lists_[i].read(f);
-  }
-
-  // set load list and active, capacity is 0 to keep current loaded lists
-  il->init(nullptr, load_list);
-
-  return il;
-}
-
-InvertedLists* read_InvertedLists(hakes::IOReader* f, int io_flags) {
-  uint32_t h;
-  READ1(h);
-  if (h == fourcc("il00")) {
-    // fprintf(stderr,
-    //         "read_InvertedLists:"
-    //         " WARN! inverted lists not stored with IVF object\n");
-    assert(!"inverted lists not stored with IVF object");
-    return nullptr;
-  } else if (h == fourcc("ilar") && !(io_flags & IO_FLAG_SKIP_IVF_DATA)) {
-    auto ails = new ArrayInvertedLists(0, 0);
-    READ1(ails->nlist);
-    READ1(ails->code_size);
-    ails->ids.resize(ails->nlist);
-    ails->codes.resize(ails->nlist);
-    std::vector<size_t> sizes(ails->nlist);
-    read_ArrayInvertedLists_sizes(f, sizes);
-    for (size_t i = 0; i < ails->nlist; i++) {
-      ails->ids[i].resize(sizes[i]);
-      ails->codes[i].resize(sizes[i] * ails->code_size);
-    }
-    for (size_t i = 0; i < ails->nlist; i++) {
-      size_t n = ails->ids[i].size();
-      if (n > 0) {
-        READANDCHECK(ails->codes[i].data(), n * ails->code_size);
-        READANDCHECK(ails->ids[i].data(), n);
-      }
-    }
-    return ails;
-
-  } else if (h == fourcc("ilar") && (io_flags & IO_FLAG_SKIP_IVF_DATA)) {
-    // // code is always ilxx where xx is specific to the type of invlists we
-    // // want so we get the 16 high bits from the io_flag and the 16 low bits
-    // // as "il"
-    // int h2 = (io_flags & 0xffff0000) | (fourcc("il__") & 0x0000ffff);
-    // size_t nlist, code_size;
-    // READ1(nlist);
-    // READ1(code_size);
-    // std::vector<size_t> sizes(nlist);
-    // read_ArrayInvertedLists_sizes(f, sizes);
-    // return InvertedListsIOHook::lookup(h2)->read_ArrayInvertedLists(
-    //         f, io_flags, nlist, code_size, sizes);
-    assert(!"ilar read skip ivf data not implemented");
-    return nullptr;
-  } else {
-    assert(h == fourcc("ibll"));
-    // return InvertedListsIOHook::lookup(h)->read(f, io_flags);
-    return read_BlockInvertedLists(f);
-  }
-}
-
-void read_ProductQuantizer(ProductQuantizer* pq, hakes::IOReader* f) {
-  READ1(pq->d);
-  READ1(pq->M);
-  READ1(pq->nbits);
-  pq->set_derived_values();
-  READVECTOR(pq->centroids);
-}
-
-void write_index_header(const Index* idx, hakes::IOWriter* f) {
-  WRITE1(idx->d);
-  WRITE1(idx->ntotal);
-  idx_t dummy = 1 << 20;
-  WRITE1(dummy);
-  WRITE1(dummy);
-  WRITE1(idx->is_trained);
-  WRITE1(idx->metric_type);
-  if (idx->metric_type > 1) {
-    WRITE1(idx->metric_arg);
-  }
-}
-
-void write_BlockInvertedLists(const InvertedLists* ils_in, hakes::IOWriter* f) {
-  uint32_t h = fourcc("ibll");
-  WRITE1(h);
-  const BlockInvertedListsL* il =
-      dynamic_cast<const BlockInvertedListsL*>(ils_in);
-  WRITE1(il->nlist);
-  WRITE1(il->code_size);
-  WRITE1(il->n_per_block_);
-  WRITE1(il->block_size_);
-
-  // write the load list
-  WRITEVECTOR(il->load_list_);
-
-  for (size_t i = 0; i < il->nlist; i++) {
-    il->lists_[i].write(f);
-  }
-}
-
-void write_InvertedLists(const InvertedLists* ils, hakes::IOWriter* f) {
-  if (ils == nullptr) {
-    uint32_t h = fourcc("il00");
-    WRITE1(h);
-  } else if (const auto& ails = dynamic_cast<const ArrayInvertedLists*>(ils)) {
-    uint32_t h = fourcc("ilar");
-    WRITE1(h);
-    WRITE1(ails->nlist);
-    WRITE1(ails->code_size);
-    // here we store either as a full or a sparse data buffer
-    size_t n_non0 = 0;
-    for (size_t i = 0; i < ails->nlist; i++) {
-      if (ails->ids[i].size() > 0) n_non0++;
-    }
-    if (n_non0 > ails->nlist / 2) {
-      uint32_t list_type = fourcc("full");
-      WRITE1(list_type);
-      std::vector<size_t> sizes;
-      for (size_t i = 0; i < ails->nlist; i++) {
-        sizes.push_back(ails->ids[i].size());
-      }
-      WRITEVECTOR(sizes);
-    } else {
-      int list_type = fourcc("sprs");  // sparse
-      WRITE1(list_type);
-      std::vector<size_t> sizes;
-      for (size_t i = 0; i < ails->nlist; i++) {
-        size_t n = ails->ids[i].size();
-        if (n > 0) {
-          sizes.push_back(i);
-          sizes.push_back(n);
-        }
-      }
-      WRITEVECTOR(sizes);
-    }
-    // make a single contiguous data buffer (useful for mmapping)
-    for (size_t i = 0; i < ails->nlist; i++) {
-      size_t n = ails->ids[i].size();
-      if (n > 0) {
-        WRITEANDCHECK(ails->codes[i].data(), n * ails->code_size);
-        WRITEANDCHECK(ails->ids[i].data(), n);
-      }
-    }
-
-  } else {
-    // // printf("type name: %s\n", typeid(*ils).name());
-    // InvertedListsIOHook::lookup_classname(typeid(*ils).name())
-    //         ->write(ils, f);
-    write_BlockInvertedLists(ils, f);
-  }
-}
-
-void write_ProductQuantizer(const ProductQuantizer* pq, hakes::IOWriter* f) {
-  WRITE1(pq->d);
-  WRITE1(pq->M);
-  WRITE1(pq->nbits);
-  WRITEVECTOR(pq->centroids);
-}
-
-void write_ivfl_header(const IndexIVFL* ivf, hakes::IOWriter* f) {
-  write_index_header(ivf, f);
-  WRITE1(ivf->nlist);
-  WRITE1(ivf->nprobe);
-  // subclasses write by_residual (some of them support only one setting of
-  // by_residual).
-  write_index_ext(ivf->quantizer, f);
-}
-
-void read_ivfl_header(IndexIVFL* ivf, hakes::IOReader* f,
-                      std::vector<std::vector<idx_t>>* ids = nullptr) {
-  read_index_header(ivf, f);
-  READ1(ivf->nlist);
-  READ1(ivf->nprobe);
-  ivf->quantizer = read_index_ext(f);
-  ivf->own_fields = true;
-  if (ids) {  // used in legacy "Iv" formats
-    ids->resize(ivf->nlist);
-    for (size_t i = 0; i < ivf->nlist; i++) READVECTOR((*ids)[i]);
-  }
-}
-
-void write_refine_map(const std::unordered_map<idx_t, idx_t>& m,
-                      hakes::IOWriter* f) {
-  std::vector<std::pair<idx_t, idx_t>> v;
-  v.resize(m.size());
-  std::copy(m.begin(), m.end(), v.begin());
-  WRITEVECTOR(v);
-}
-
-void read_refine_map(std::unordered_map<idx_t, idx_t>* m, hakes::IOReader* f) {
-  std::vector<std::pair<idx_t, idx_t>> v;
-  READVECTOR(v);
-  m->clear();
-  m->reserve(v.size());
-  for (auto& p : v) {
-    (*m)[p.first] = p.second;
-  }
-}
-
-void read_InvertedLists(IndexIVFL* ivf, hakes::IOReader* f, int io_flags) {
-  InvertedLists* ils = read_InvertedLists(f, io_flags);
-  if (ils) {
-    // FAISS_THROW_IF_NOT(ils->nlist == ivf->nlist);
-    assert(ils->nlist == ivf->nlist);
-    // FAISS_THROW_IF_NOT(ils->code_size == InvertedLists::INVALID_CODE_SIZE ||
-    //                    ils->code_size == ivf->code_size);
-    assert(ils->code_size == InvertedLists::INVALID_CODE_SIZE ||
-           ils->code_size == ivf->code_size);
-  }
-  ivf->invlists = ils;
-  ivf->own_invlists = true;
-}
-}  // anonymous namespace
-
-void write_index_ext(const Index* idx, hakes::IOWriter* f) {
-  // check the new types before falling back to the original implementation
-  if (const IndexFlatL* idxf = dynamic_cast<const IndexFlatL*>(idx)) {
-    // same impl as IndexFlat, but with different fourcc for load
-    uint32_t h = fourcc(idxf->metric_type == METRIC_INNER_PRODUCT ? "IlFI"
-                        : idxf->metric_type == METRIC_L2          ? "IlF2"
-                                                                  : "IlFl");
-    WRITE1(h);
-    write_index_header(idx, f);
-    WRITEXBVECTOR(idxf->codes);
-  } else if (const IndexRefineL* idxrf =
-                 dynamic_cast<const IndexRefineL*>(idx)) {
-    // Here we also need to store the mapping
-    uint32_t h = fourcc("IlRF");
-    WRITE1(h);
-    // additionally store the two mapping
-    write_refine_map(idxrf->off_to_idx, f);
-    write_refine_map(idxrf->idx_to_off, f);
-
-    write_index_header(idxrf, f);
-    write_index_ext(idxrf->base_index, f);
-    write_index_ext(idxrf->refine_index, f);
-    WRITE1(idxrf->k_factor);
-  } else if (const IndexIVFPQFastScanL* ivpq_2 =
-                 dynamic_cast<const IndexIVFPQFastScanL*>(idx)) {
-    // here we need to use the block inverted list locking IO
-    uint32_t h = fourcc("IlPf");
-    WRITE1(h);
-    write_ivfl_header(ivpq_2, f);
-    WRITE1(ivpq_2->by_residual);
-    WRITE1(ivpq_2->code_size);
-    WRITE1(ivpq_2->bbs);
-    WRITE1(ivpq_2->M2);
-    WRITE1(ivpq_2->implem);
-    WRITE1(ivpq_2->qbs2);
-    write_ProductQuantizer(&ivpq_2->pq, f);
-    write_InvertedLists(ivpq_2->invlists, f);
-  } else {
-    // write_index(idx, f);
-    assert(!"other index not supported to write in hakes");
-  }
-}
-
-Index* read_index_ext(hakes::IOReader* f, int io_flags) {
-  Index* idx = nullptr;
-  uint32_t h;
-  READ1(h);
-  if (h == fourcc("IlFI") || h == fourcc("IlF2") || h == fourcc("IlFl")) {
-    IndexFlatL* idxf;
-    if (h == fourcc("IlFI")) {
-      idxf = new IndexFlatLIP();
-    } else if (h == fourcc("IlF2")) {
-      idxf = new IndexFlatLL2();
-    } else {
-      idxf = new IndexFlatL();
-    }
-    read_index_header(idxf, f);
-    idxf->code_size = idxf->d * sizeof(float);
-    idxf->codes.reserve(idxf->ntotal * idxf->code_size * 2);
-    READXBVECTOR(idxf->codes);
-    // FAISS_THROW_IF_NOT(idxf->codes.size() == idxf->ntotal * idxf->code_size);
-    assert(idxf->codes.size() == idxf->ntotal * idxf->code_size);
-    idx = idxf;
-  } else if (h == fourcc("IlRF")) {
-    IndexRefineL* idxrf = new IndexRefineL();
-    read_refine_map(&idxrf->off_to_idx, f);
-    read_refine_map(&idxrf->idx_to_off, f);
-
-    read_index_header(idxrf, f);
-    idxrf->base_index = read_index_ext(f, io_flags);
-    // print memory after loading base index
-    // printf("Memory after loading base index: %ld\n",
-    //        getCurrentRSS() / 1024 / 1024);
-    idxrf->refine_index = read_index_ext(f, io_flags);
-    READ1(idxrf->k_factor);
-    if (dynamic_cast<IndexFlatL*>(idxrf->refine_index)) {
-      // then make a RefineFlat with it
-      IndexRefineL* idxrf_old = idxrf;
-      idxrf = new IndexRefineFlatL();
-      *idxrf = *idxrf_old;
-      delete idxrf_old;
-    }
-    idxrf->own_fields = true;
-    idxrf->own_refine_index = true;
-    idx = idxrf;
-    // printf("Memory after loading refine index: %ld\n",
-    //        getCurrentRSS() / 1024 / 1024);
-  } else if (h == fourcc("IlPf")) {
-    IndexIVFPQFastScanL* ivpq = new IndexIVFPQFastScanL();
-    read_ivfl_header(ivpq, f);
-    READ1(ivpq->by_residual);
-    READ1(ivpq->code_size);
-    READ1(ivpq->bbs);
-    READ1(ivpq->M2);
-    READ1(ivpq->implem);
-    READ1(ivpq->qbs2);
-    read_ProductQuantizer(&ivpq->pq, f);
-    read_InvertedLists(ivpq, f, io_flags);
-    ivpq->precompute_table();
-
-    const auto& pq = ivpq->pq;
-    ivpq->M = pq.M;
-    ivpq->nbits = pq.nbits;
-    ivpq->ksub = (1 << pq.nbits);
-    ivpq->code_size = pq.code_size;
-    // printf("code_size: %ld\n", ivpq->code_size);
-    ivpq->init_code_packer();
-
-    idx = ivpq;
-  } else {
-    // idx = read_index(f, io_flags);
-    assert(!"other index not supported to read in hakes");
-  }
-  return idx;
-}
-
 bool read_hakes_pretransform(hakes::IOReader* f,
                              std::vector<VectorTransform*>* vts) {
   // open pretransform file
@@ -440,42 +56,6 @@ bool read_hakes_pretransform(hakes::IOReader* f,
     vts->emplace_back(lt);
   }
   printf("read_hakes_pretransform: num_vt: %d\n", num_vt);
-  return true;
-}
-
-IndexFlatL* read_hakes_ivf(hakes::IOReader* f, MetricType metric,
-                           bool* use_residual) {
-  // open ivf file
-  int32_t by_residual;
-  READ1(by_residual);
-  *use_residual = (by_residual == 1);
-  int32_t nlist, d;
-  READ1(nlist);
-  READ1(d);
-  IndexFlatL* ivf = new IndexFlatL(d, metric);
-  size_t code_size = nlist * d * sizeof(float);
-  std::vector<uint8_t> codes(code_size);
-  READANDCHECK(codes.data(), code_size);
-  // printf("codes read size: %ld\n", code_size);
-  ivf->codes = std::move(codes);
-  ivf->is_trained = true;
-  ivf->ntotal = nlist;
-  return ivf;
-}
-
-bool read_hakes_pq(hakes::IOReader* f, ProductQuantizer* pq) {
-  // open pq file
-  int32_t d, M, nbits;
-  READ1(d);
-  READ1(M);
-  READ1(nbits);
-  pq->d = d;
-  pq->M = M;
-  pq->nbits = nbits;
-  pq->set_derived_values();
-  pq->train_type = ProductQuantizer::Train_hot_start;
-  size_t centroids_size = pq->M * pq->ksub * pq->dsub;
-  READANDCHECK(pq->centroids.data(), centroids_size);
   return true;
 }
 
@@ -507,268 +87,7 @@ bool write_hakes_pretransform(hakes::IOWriter* f,
   return true;
 }
 
-bool write_hakes_ivf(hakes::IOWriter* f, const Index* idx, bool use_residual) {
-  const IndexFlatL* quantizer = dynamic_cast<const IndexFlatL*>(idx);
-  if (quantizer == nullptr) {
-    // printf("write_hakes_ivf: Only IndexFlatL is supported\n");
-    return false;
-  }
-  int32_t by_residual = use_residual ? 1 : 0;
-  WRITE1(by_residual);
-  int32_t nlist = quantizer->ntotal;
-  int32_t d = quantizer->d;
-  WRITE1(nlist);
-  WRITE1(d);
-  size_t code_size = nlist * d * sizeof(float);
-  WRITEANDCHECK(quantizer->codes.data(), code_size);
-  return true;
-}
-
-bool write_hakes_pq(hakes::IOWriter* f, const ProductQuantizer& pq) {
-  int32_t d = pq.d;
-  int32_t M = pq.M;
-  int32_t nbits = pq.nbits;
-  WRITE1(d);
-  WRITE1(M);
-  WRITE1(nbits);
-  size_t centroids_size = M * pq.ksub * pq.dsub;
-  WRITEANDCHECK(pq.centroids.data(), centroids_size);
-  return true;
-}
-
-std::unordered_map<faiss::idx_t, faiss::idx_t> read_pa_mapping(
-    hakes::IOReader* f) {
-  // open pa mapping file
-  std::vector<std::pair<idx_t, idx_t>> v;
-  READVECTOR(v);
-  std::unordered_map<faiss::idx_t, faiss::idx_t> pa_mapping;
-  pa_mapping.reserve(v.size());
-  for (auto& p : v) {
-    pa_mapping[p.first] = p.second;
-  }
-  return pa_mapping;
-}
-
-bool write_hakes_ivf2(hakes::IOWriter* f, const IndexFlat* idx,
-                      bool use_residual) {
-  int32_t by_residual = use_residual ? 1 : 0;
-  WRITE1(by_residual);
-  int32_t nlist = idx->ntotal;
-  int32_t d = idx->d;
-  WRITE1(nlist);
-  WRITE1(d);
-  size_t code_size = nlist * d * sizeof(float);
-  WRITEANDCHECK(idx->codes.data(), code_size);
-  return true;
-}
-
-bool write_hakes_vt_quantizers(hakes::IOWriter* f,
-                               const std::vector<VectorTransform*>& pq_vts,
-                               const IndexFlat* ivf_centroids,
-                               const ProductQuantizer* pq) {
-  if ((ivf_centroids == nullptr) || (pq == nullptr)) {
-    // printf("write_hakes_vt_quantizers: ivf_centroids or pq is nullptr\n");
-    return false;
-  }
-  // write pq vts
-  if (!write_hakes_pretransform(f, &pq_vts)) {
-    // printf("write_hakes_vt_quantizers: write pq vts failed\n");
-    return false;
-  }
-
-  // write ivf
-  if (!write_hakes_ivf2(f, ivf_centroids, false)) {
-    // printf("write_hakes_vt_quantizers: write ivf failed\n");
-    return false;
-  }
-
-  // write pq
-  if (!write_hakes_pq(f, *pq)) {
-    // printf("write_hakes_vt_quantizers: write pq failed\n");
-    return false;
-  }
-
-  return true;
-}
-
-Index* load_hakes_vt_quantizers(hakes::IOReader* f, MetricType metric,
-                                std::vector<VectorTransform*>* pq_vts) {
-  assert(pq_vts != nullptr);
-
-  // load pq vts
-  read_hakes_pretransform(f, pq_vts);
-
-  // load ivf
-  bool use_residual;
-  IndexFlatL* quantizer = read_hakes_ivf(f, metric, &use_residual);
-
-  // load pq
-  IndexIVFPQFastScanL* base_index = new IndexIVFPQFastScanL();
-  read_hakes_pq(f, &base_index->pq);
-  // read_index_header
-  // use the opq vt to get the d
-  base_index->d = pq_vts->back()->d_out;
-  base_index->metric_type = metric;
-  // read_ivfl_header
-  base_index->nlist = quantizer->ntotal;
-  base_index->quantizer = quantizer;
-  base_index->own_fields = true;
-  // read_index_ext IVFPQFastScanL branch
-  base_index->by_residual = use_residual;
-  base_index->code_size = base_index->pq.code_size;
-  // printf("code size: %ld\n", base_index->code_size);
-  base_index->bbs = 32;
-  base_index->M = base_index->pq.M;
-  base_index->M2 = (base_index->M + 1) / 2 * 2;
-  // printf("M2: %ld\n", base_index->M2);
-  base_index->implem = 0;
-  base_index->qbs2 = 0;
-
-  // read_InvertedLists
-  CodePacker* code_packer = base_index->get_CodePacker();
-  BlockInvertedListsL* il = new BlockInvertedListsL(
-      base_index->nlist, code_packer->nvec, code_packer->block_size);
-  il->init(nullptr, std::vector<int>());
-  base_index->invlists = il;
-  base_index->own_invlists = true;
-  base_index->nbits = base_index->pq.nbits;
-  base_index->ksub = 1 << base_index->pq.nbits;
-  base_index->code_size = base_index->pq.code_size;
-  base_index->init_code_packer();
-
-  base_index->is_trained = true;
-
-  delete code_packer;
-  return base_index;
-}
-
-// |---#vts----|---vts---|---ivf---|---pq---|
-bool write_hakes_index_params(hakes::IOWriter* f,
-                              const std::vector<VectorTransform*>& vts,
-                              const std::vector<VectorTransform*>& ivf_vts,
-                              const IndexFlatL* ivf_centroids,
-                              const ProductQuantizer* pq) {
-  // write vts
-  if (!write_hakes_pretransform(f, &vts)) {
-    // printf("write_hakes_index_params: write pq vts failed\n");
-    return false;
-  }
-
-  // write ivf vts
-  if (!write_hakes_pretransform(f, &ivf_vts)) {
-    // printf("write_hakes_index_params: write ivf vts failed\n");
-    return false;
-  }
-
-  // write ivf
-  if (!write_hakes_ivf(f, ivf_centroids, false)) {
-    // printf("write_hakes_index_params: write ivf failed\n");
-    return false;
-  }
-
-  // write pq
-  if (!write_hakes_pq(f, *pq)) {
-    // printf("write_hakes_index_params: write pq failed\n");
-    return false;
-  }
-  return true;
-}
-
-// many fields of the returned index is not initialized. just the parameters
-HakesIndex* load_hakes_index_params(hakes::IOReader* f) {
-  HakesIndex* index = new HakesIndex();
-
-  // load pq vts
-  read_hakes_pretransform(f, &index->vts_);
-
-  // load ivf vts
-  // read_hakes_pretransform(f, &index->ivf_vts_);
-
-  // load ivf
-  bool use_residual;
-  IndexFlatL* quantizer =
-      read_hakes_ivf(f, METRIC_INNER_PRODUCT, &use_residual);
-
-  // load pq
-
-  // assemble
-  IndexIVFPQFastScanL* base_index = new IndexIVFPQFastScanL();
-  read_hakes_pq(f, &base_index->pq);
-  base_index->d = index->vts_.back()->d_out;
-  base_index->metric_type = METRIC_INNER_PRODUCT;
-  base_index->nlist = quantizer->ntotal;
-  base_index->quantizer = quantizer;
-  base_index->own_fields = true;
-  base_index->by_residual = use_residual;
-  base_index->code_size = base_index->pq.code_size;
-  base_index->bbs = 32;
-  base_index->M = base_index->pq.M;
-  base_index->M2 = (base_index->M + 1) / 2 * 2;
-  base_index->implem = 0;
-  base_index->qbs2 = 0;
-  index->base_index_.reset(base_index);
-  index->cq_ = index->base_index_->quantizer;
-  return index;
-}
-
-bool load_hakes_index_single_file(hakes::IOReader* f, HakesIndex* idx) {
-  if (!read_hakes_pretransform(f, &idx->vts_)) {
-    return false;
-  }
-  idx->base_index_.reset(
-      dynamic_cast<faiss::IndexIVFPQFastScanL*>(read_index_ext(f)));
-  idx->mapping_->load(f);
-  idx->refine_index_.reset(dynamic_cast<faiss::IndexFlatL*>(read_index_ext(f)));
-  return true;
-}
-
-bool write_hakes_index_single_file(hakes::IOWriter* f, const HakesIndex* idx) {
-  if (!write_hakes_pretransform(f, &idx->vts_)) {
-    return false;
-  }
-  write_index_ext(idx->base_index_.get(), f);
-  if (!idx->mapping_->save(f)) {
-    return false;
-  }
-  write_index_ext(idx->refine_index_.get(), f);
-  return true;
-}
-
-bool load_hakes_findex(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa) {
-  if (!read_hakes_pretransform(ff, &idx->vts_)) {
-    return false;
-  }
-  idx->base_index_.reset(
-      dynamic_cast<faiss::IndexIVFPQFastScanL*>(read_index_ext(ff)));
-  return (idx->base_index_ != nullptr);
-}
-
-bool load_hakes_rindex(hakes::IOReader* rf, int d, HakesIndex* idx,
-                       bool keep_pa) {
-  idx->mapping_->load(rf);
-  idx->refine_index_.reset(
-      dynamic_cast<faiss::IndexFlatL*>(read_index_ext(rf)));
-  return true;
-}
-
-bool load_hakes_index(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
-                      bool keep_pa) {
-  if (!load_hakes_findex(ff, idx, keep_pa)) {
-    return false;
-  }
-  if (rf) {
-    return load_hakes_rindex(rf, idx->vts_.back()->d_out, idx, keep_pa);
-  } else {
-    idx->mapping_.reset(new faiss::IDMapImpl());
-    int refine_d =
-        (idx->vts_.empty()) ? idx->base_index_->d : idx->vts_.front()->d_in;
-    idx->refine_index_.reset(
-        new faiss::IndexFlatL(refine_d, idx->base_index_->metric_type));
-    return true;
-  }
-}
-
-void write_hakes_ivf_new(hakes::IOWriter* f, const HakesIndex* idx) {
+void write_hakes_ivf(hakes::IOWriter* f, const HakesIndex* idx) {
   uint32_t d = idx->base_index_->d;
   uint64_t ntotal = idx->base_index_->ntotal;
   uint8_t metric_type = (idx->base_index_->metric_type == METRIC_L2) ? 0 : 1;
@@ -782,11 +101,12 @@ void write_hakes_ivf_new(hakes::IOWriter* f, const HakesIndex* idx) {
   WRITEANDCHECK(
       static_cast<IndexFlatL*>(idx->base_index_->quantizer)->codes.data(),
       code_size);
-  printf("write_hakes_ivf_new: d: %d, ntotal: %ld, nlist: %ld\n",
-         idx->base_index_->d, idx->base_index_->ntotal, idx->base_index_->nlist);
+  printf("write_hakes_ivf: d: %d, ntotal: %ld, nlist: %ld\n",
+         idx->base_index_->d, idx->base_index_->ntotal,
+         idx->base_index_->nlist);
 }
 
-bool read_hakes_ivf_new(hakes::IOReader* f, HakesIndex* idx) {
+bool read_hakes_ivf(hakes::IOReader* f, HakesIndex* idx) {
   uint32_t d;
   uint64_t ntotal;
   uint8_t metric_type;
@@ -795,15 +115,13 @@ bool read_hakes_ivf_new(hakes::IOReader* f, HakesIndex* idx) {
   READ1(metric_type);
   idx->base_index_->d = d;
   idx->base_index_->ntotal = ntotal;
-  faiss::MetricType metric = (metric_type == 0)
-                                 ? faiss::METRIC_L2
-                                 : faiss::METRIC_INNER_PRODUCT;
+  faiss::MetricType metric =
+      (metric_type == 0) ? faiss::METRIC_L2 : faiss::METRIC_INNER_PRODUCT;
   idx->base_index_->metric_type = metric;
   size_t nlist;
   READ1(nlist);
   idx->base_index_->nlist = nlist;
-  printf("read_hakes_ivf_new: d: %d, ntotal: %ld, nlist: %ld\n", d, ntotal,
-         nlist);
+  printf("read_hakes_ivf: d: %d, ntotal: %ld, nlist: %ld\n", d, ntotal, nlist);
 
   IndexFlatL* quantizer = new IndexFlatL(d, metric);
   size_t code_size = nlist * d * sizeof(float);
@@ -815,7 +133,7 @@ bool read_hakes_ivf_new(hakes::IOReader* f, HakesIndex* idx) {
   return true;
 }
 
-void write_hakes_pq_new(hakes::IOWriter* f, const HakesIndex* idx) {
+void write_hakes_pq(hakes::IOWriter* f, const HakesIndex* idx) {
   ProductQuantizer* pq = &idx->base_index_->pq;
   WRITE1(pq->d);
   WRITE1(pq->M);
@@ -824,12 +142,12 @@ void write_hakes_pq_new(hakes::IOWriter* f, const HakesIndex* idx) {
   WRITEANDCHECK(pq->centroids.data(), centroids_size);
 }
 
-bool read_hakes_pq_new(hakes::IOReader* f, HakesIndex* idx) {
+bool read_hakes_pq(hakes::IOReader* f, HakesIndex* idx) {
   size_t d, M, nbits;
   READ1(d);
   READ1(M);
   READ1(nbits);
-  printf("read_hakes_pq_new: d: %ld, M: %ld, nbits: %ld\n", d, M, nbits);
+  printf("read_hakes_pq: d: %ld, M: %ld, nbits: %ld\n", d, M, nbits);
   ProductQuantizer* pq = &idx->base_index_->pq;
   pq->d = d;
   pq->M = M;
@@ -838,6 +156,7 @@ bool read_hakes_pq_new(hakes::IOReader* f, HakesIndex* idx) {
   pq->train_type = ProductQuantizer::Train_hot_start;
   size_t centroids_size = pq->M * pq->ksub * pq->dsub;
   pq->centroids.resize(centroids_size);
+  printf("centroids_size: %ld\n", centroids_size);
   READANDCHECK(pq->centroids.data(), centroids_size);
   return true;
 }
@@ -863,13 +182,15 @@ bool read_hakes_compressed_vecs(hakes::IOReader* f, HakesIndex* idx) {
   READ1(code_size);
   READ1(n_per_block);
   READ1(block_size);
-  printf("read_hakes_compressed_vecs: nlist: %ld, code_size: %ld, n_per_block: %ld, block_size: %ld\n",
-         nlist, code_size, n_per_block, block_size);
+  printf(
+      "read_hakes_compressed_vecs: nlist: %ld, code_size: %ld, n_per_block: "
+      "%ld, block_size: %ld\n",
+      nlist, code_size, n_per_block, block_size);
 
   READVECTOR(load_list);
-  
-  BlockInvertedListsL* il = new BlockInvertedListsL(nlist, n_per_block,
-                                                    block_size);
+
+  BlockInvertedListsL* il =
+      new BlockInvertedListsL(nlist, n_per_block, block_size);
   for (size_t i = 0; i < nlist; i++) {
     il->lists_[i].read(f);
   }
@@ -896,9 +217,9 @@ bool read_hakes_full_vecs(hakes::IOReader* f, HakesIndex* idx) {
   READ1(d);
   READ1(ntotal);
   READ1(metric_type);
-  if (metric_type == METRIC_L2) {
+  if (metric_type == 0) {
     idx->refine_index_.reset(new faiss::IndexFlatLL2(d));
-  } else if (metric_type == METRIC_INNER_PRODUCT) {
+  } else if (metric_type == 1) {
     idx->refine_index_.reset(new faiss::IndexFlatLIP(d));
   } else {
     // printf("read_hakes_full_vecs: metric type not supported\n");
@@ -911,15 +232,16 @@ bool read_hakes_full_vecs(hakes::IOReader* f, HakesIndex* idx) {
   READXBVECTOR(idx->refine_index_->codes);
   assert(idx->refine_index_->codes.size() ==
          idx->refine_index_->ntotal * idx->refine_index_->code_size);
+  return true;
 }
 
 void save_hakes_findex(hakes::IOWriter* ff, const HakesIndex* idx) {
   write_hakes_pretransform(ff, &idx->vts_);
   printf("write_hakes_pretransform\n");
-  write_hakes_ivf_new(ff, idx);
-  printf("write_hakes_ivf_new\n");
-  write_hakes_pq_new(ff, idx);
-  printf("write_hakes_pq_new\n");
+  write_hakes_ivf(ff, idx);
+  printf("write_hakes_ivf\n");
+  write_hakes_pq(ff, idx);
+  printf("write_hakes_pq\n");
   write_hakes_compressed_vecs(ff, idx);
   printf("write_hakes_compressed_vecs\n");
 }
@@ -935,13 +257,13 @@ void save_hakes_index(hakes::IOWriter* ff, hakes::IOWriter* rf,
   save_hakes_rindex(rf, idx);
 }
 
-bool load_hakes_findex_new(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa) {
+bool load_hakes_findex(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa) {
   if (!read_hakes_pretransform(ff, &idx->vts_)) {
     return false;
   }
   idx->base_index_.reset(new faiss::IndexIVFPQFastScanL());
-  bool success = read_hakes_ivf_new(ff, idx) && read_hakes_pq_new(ff, idx) &&
-         read_hakes_compressed_vecs(ff, idx);
+  bool success = read_hakes_ivf(ff, idx) && read_hakes_pq(ff, idx) &&
+                 read_hakes_compressed_vecs(ff, idx);
   if (!success) {
     return false;
   }
@@ -962,32 +284,33 @@ bool load_hakes_findex_new(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa) {
   idx->base_index_->init_code_packer();
   idx->base_index_->precompute_table();
   printf("code size: %ld\n", idx->base_index_->code_size);
-  printf("bbs: %ld\n", idx->base_index_->bbs);
+  printf("bbs: %d\n", idx->base_index_->bbs);
   printf("M2: %ld\n", idx->base_index_->M2);
-  printf("implem: %ld\n", idx->base_index_->implem);
+  printf("implem: %d\n", idx->base_index_->implem);
   printf("qbs2: %ld\n", idx->base_index_->qbs2);
   printf("nbits: %ld\n", idx->base_index_->nbits);
   printf("ksub: %ld\n", idx->base_index_->ksub);
   printf("nlist: %ld\n", idx->base_index_->nlist);
   printf("ntotal: %ld\n", idx->base_index_->ntotal);
-  printf("d: %ld\n", idx->base_index_->d);
+  printf("d: %d\n", idx->base_index_->d);
 
   return true;
 }
 
-bool load_hakes_rindex_new(hakes::IOReader* rf, int d, HakesIndex* idx,
-                           bool keep_pa) {
+bool load_hakes_rindex(hakes::IOReader* rf, int d, HakesIndex* idx,
+                       bool keep_pa) {
+  idx->mapping_.reset(new faiss::IDMapImpl());
   idx->mapping_->load(rf);
   return read_hakes_full_vecs(rf, idx);
 }
 
-bool load_hakes_index_new(hakes::IOReader* ff, hakes::IOReader* rf,
-                          HakesIndex* idx, bool keep_pa) {
-  if (!load_hakes_findex_new(ff, idx, keep_pa)) {
+bool load_hakes_index(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
+                      bool keep_pa) {
+  if (!load_hakes_findex(ff, idx, keep_pa)) {
     return false;
   }
   if (rf) {
-    return load_hakes_rindex_new(rf, idx->vts_.back()->d_out, idx, keep_pa);
+    return load_hakes_rindex(rf, idx->vts_.back()->d_out, idx, keep_pa);
   } else {
     idx->mapping_.reset(new faiss::IDMapImpl());
     int refine_d =
@@ -996,6 +319,48 @@ bool load_hakes_index_new(hakes::IOReader* ff, hakes::IOReader* rf,
         new faiss::IndexFlatL(refine_d, idx->base_index_->metric_type));
     return true;
   }
+}
+
+bool load_hakes_params(hakes::IOReader* f, HakesIndex* idx) {
+  if (!read_hakes_pretransform(f, &idx->vts_)) {
+    return false;
+  }
+  idx->base_index_.reset(new faiss::IndexIVFPQFastScanL());
+  bool success = read_hakes_ivf(f, idx) && read_hakes_pq(f, idx);
+  if (!success) {
+    return false;
+  }
+  // default field settings
+  idx->base_index_->by_residual = false;
+  idx->base_index_->nprobe = 1;
+  idx->base_index_->own_fields = true;
+  idx->base_index_->is_trained = true;
+  assert(idx->base_index_->d == idx->vts_.back()->d_out);
+  idx->base_index_->bbs = 32;
+  idx->base_index_->M = idx->base_index_->pq.M;
+  idx->base_index_->M2 = (idx->base_index_->M + 1) / 2 * 2;
+  idx->base_index_->implem = 0;
+  idx->base_index_->qbs2 = 0;
+  idx->base_index_->nbits = idx->base_index_->pq.nbits;
+  idx->base_index_->ksub = 1 << idx->base_index_->pq.nbits;
+  idx->base_index_->code_size = idx->base_index_->pq.code_size;
+  idx->base_index_->precompute_table();
+
+  auto code_packer = idx->base_index_->get_CodePacker();
+  auto il = new BlockInvertedListsL(idx->base_index_->nlist, code_packer->nvec,
+                                    code_packer->block_size);
+  il->init(nullptr, std::vector<int>());
+  idx->base_index_->invlists = il;
+  idx->base_index_->own_invlists = true;
+  idx->base_index_->init_code_packer();
+  delete code_packer;
+  return true;
+}
+
+void save_hakes_params(hakes::IOWriter* f, const HakesIndex* idx) {
+  write_hakes_pretransform(f, &idx->vts_);
+  write_hakes_ivf(f, idx);
+  write_hakes_pq(f, idx);
 }
 
 }  // namespace faiss

--- a/search-worker/index/ext/index_io_ext.h
+++ b/search-worker/index/ext/index_io_ext.h
@@ -79,6 +79,19 @@ bool load_hakes_rindex(hakes::IOReader* rf, int d, HakesIndex* idx,
 bool load_hakes_index(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
                       bool keep_pa);
 
+bool load_hakes_findex_new(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa);
+bool load_hakes_rindex_new(hakes::IOReader* rf, int d, HakesIndex* idx,
+                       bool keep_pa);
+bool load_hakes_index_new(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
+                      bool keep_pa);
+
+void save_hakes_findex(hakes::IOWriter* ff, const HakesIndex* idx);
+
+void save_hakes_rindex(hakes::IOWriter* rf, const HakesIndex* idx);
+
+void save_hakes_index(hakes::IOWriter* ff, hakes::IOWriter* rf,
+                      const HakesIndex* idx);
+
 }  // namespace faiss
 
 #endif  // HAKES_SEARCHWORKER_INDEX_EXT_INDEXIOEXT_H_

--- a/search-worker/index/ext/index_io_ext.h
+++ b/search-worker/index/ext/index_io_ext.h
@@ -21,7 +21,7 @@
 #include "search-worker/index/VectorTransform.h"
 #include "search-worker/index/ext/HakesIndex.h"
 #include "search-worker/index/ext/IdMap.h"
-#include "search-worker/index/impl/io.h"
+#include "utils/io.h"
 
 namespace faiss {
 
@@ -47,45 +47,37 @@ const int IO_FLAG_MMAP = IO_FLAG_SKIP_IVF_DATA | 0x646f0000;
 
 struct Index;
 
-struct StringIOReader : IOReader {
-  StringIOReader(const char* data, size_t data_len)
-      : data(data), data_len(data_len) {}
-  const char* data;
-  size_t data_len;
-  size_t rp = 0;
-  size_t operator()(void* ptr, size_t size, size_t nitems) override;
-};
-
-struct StringIOWriter : IOWriter {
-  std::string data;
-  size_t operator()(const void* ptr, size_t size, size_t nitems) override;
-};
-
 // the io utilities are not thread safe, needs external synchronization
 
 // void write_index_ext(const Index* idx, const char* fname);
-void write_index_ext(const Index* idx, IOWriter* f);
+void write_index_ext(const Index* idx, hakes::IOWriter* f);
 
-Index* read_index_ext(IOReader* f, int io_flags = 0);
+Index* read_index_ext(hakes::IOReader* f, int io_flags = 0);
 
-bool write_hakes_vt_quantizers(IOWriter* f,
+bool write_hakes_vt_quantizers(hakes::IOWriter* f,
                                const std::vector<VectorTransform*>& pq_vts,
                                const IndexFlat* ivf_centroids,
                                const ProductQuantizer* pq);
 
-Index* load_hakes_vt_quantizers(IOReader* f, MetricType metric,
+Index* load_hakes_vt_quantizers(hakes::IOReader* f, MetricType metric,
                                 std::vector<VectorTransform*>* pq_vts);
 
-bool write_hakes_index_params(IOWriter* f,
+bool write_hakes_index_params(hakes::IOWriter* f,
                               const std::vector<VectorTransform*>& pq_vts,
                               const std::vector<VectorTransform*>& ivf_vts,
                               const IndexFlatL* ivf_centroids,
                               const ProductQuantizer* pq);
 
-HakesIndex* load_hakes_index_params(IOReader* f);
+HakesIndex* load_hakes_index_params(hakes::IOReader* f);
 
-bool load_hakes_index_single_file(IOReader* f, HakesIndex* idx);
-bool write_hakes_index_single_file(IOWriter* f, const HakesIndex* idx);
+bool load_hakes_index_single_file(hakes::IOReader* f, HakesIndex* idx);
+bool write_hakes_index_single_file(hakes::IOWriter* f, const HakesIndex* idx);
+
+bool load_hakes_findex(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa);
+bool load_hakes_rindex(hakes::IOReader* rf, int d, HakesIndex* idx,
+                       bool keep_pa);
+bool load_hakes_index(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
+                      bool keep_pa);
 
 }  // namespace faiss
 

--- a/search-worker/index/ext/index_io_ext.h
+++ b/search-worker/index/ext/index_io_ext.h
@@ -24,65 +24,15 @@
 #include "utils/io.h"
 
 namespace faiss {
-
-/**
- * from index_io.h
- */
-// The read_index flags are implemented only for a subset of index types.
-const int IO_FLAG_READ_ONLY = 2;
-// strip directory component from ondisk filename, and assume it's in
-// the same directory as the index file
-const int IO_FLAG_ONDISK_SAME_DIR = 4;
-// don't load IVF data to RAM, only list sizes
-const int IO_FLAG_SKIP_IVF_DATA = 8;
-// don't initialize precomputed table after loading
-const int IO_FLAG_SKIP_PRECOMPUTE_TABLE = 16;
-// try to memmap data (useful to load an ArrayInvertedLists as an
-// OnDiskInvertedLists)
-const int IO_FLAG_MMAP = IO_FLAG_SKIP_IVF_DATA | 0x646f0000;
-
-/**
- * from index_io.h
- */
-
-struct Index;
-
 // the io utilities are not thread safe, needs external synchronization
 
-// void write_index_ext(const Index* idx, const char* fname);
-void write_index_ext(const Index* idx, hakes::IOWriter* f);
-
-Index* read_index_ext(hakes::IOReader* f, int io_flags = 0);
-
-bool write_hakes_vt_quantizers(hakes::IOWriter* f,
-                               const std::vector<VectorTransform*>& pq_vts,
-                               const IndexFlat* ivf_centroids,
-                               const ProductQuantizer* pq);
-
-Index* load_hakes_vt_quantizers(hakes::IOReader* f, MetricType metric,
-                                std::vector<VectorTransform*>* pq_vts);
-
-bool write_hakes_index_params(hakes::IOWriter* f,
-                              const std::vector<VectorTransform*>& pq_vts,
-                              const std::vector<VectorTransform*>& ivf_vts,
-                              const IndexFlatL* ivf_centroids,
-                              const ProductQuantizer* pq);
-
-HakesIndex* load_hakes_index_params(hakes::IOReader* f);
-
-bool load_hakes_index_single_file(hakes::IOReader* f, HakesIndex* idx);
-bool write_hakes_index_single_file(hakes::IOWriter* f, const HakesIndex* idx);
+bool load_hakes_params(hakes::IOReader* f, HakesIndex* idx);
+void save_hakes_params(hakes::IOWriter* f, const HakesIndex* idx);
 
 bool load_hakes_findex(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa);
 bool load_hakes_rindex(hakes::IOReader* rf, int d, HakesIndex* idx,
                        bool keep_pa);
 bool load_hakes_index(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
-                      bool keep_pa);
-
-bool load_hakes_findex_new(hakes::IOReader* ff, HakesIndex* idx, bool keep_pa);
-bool load_hakes_rindex_new(hakes::IOReader* rf, int d, HakesIndex* idx,
-                       bool keep_pa);
-bool load_hakes_index_new(hakes::IOReader* ff, hakes::IOReader* rf, HakesIndex* idx,
                       bool keep_pa);
 
 void save_hakes_findex(hakes::IOWriter* ff, const HakesIndex* idx);

--- a/search-worker/index/impl/ProductQuantizer.cpp
+++ b/search-worker/index/impl/ProductQuantizer.cpp
@@ -20,27 +20,34 @@
 #include "search-worker/index/VectorTransform.h"
 // #include <faiss/impl/FaissAssert.h>
 #include "search-worker/index/utils/distances.h"
-#include "search-worker/index/blas/sgemm.h"
 
-// extern "C" {
+#ifdef USE_SGX
+// #include "search-worker/index/blas/sgemm.h"
+#else // USE_SGX
+extern "C" {
 
-// /* declare BLAS functions, see http://www.netlib.org/clapack/cblas/ */
+#ifndef FINTEGER
+#define FINTEGER long
+#endif
 
-// int sgemm_(
-//         const char* transa,
-//         const char* transb,
-//         FINTEGER* m,
-//         FINTEGER* n,
-//         FINTEGER* k,
-//         const float* alpha,
-//         const float* a,
-//         FINTEGER* lda,
-//         const float* b,
-//         FINTEGER* ldb,
-//         float* beta,
-//         float* c,
-//         FINTEGER* ldc);
-// }
+/* declare BLAS functions, see http://www.netlib.org/clapack/cblas/ */
+
+int sgemm_(
+        const char* transa,
+        const char* transb,
+        FINTEGER* m,
+        FINTEGER* n,
+        FINTEGER* k,
+        const float* alpha,
+        const float* a,
+        FINTEGER* lda,
+        const float* b,
+        FINTEGER* ldb,
+        float* beta,
+        float* c,
+        FINTEGER* ldc);
+}
+#endif // USE_SGX
 
 namespace faiss {
 

--- a/search-worker/index/impl/ScalarQuantizer.cpp
+++ b/search-worker/index/impl/ScalarQuantizer.cpp
@@ -1,0 +1,1887 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#include <search-worker/index/impl/ScalarQuantizer.h>
+
+#include <algorithm>
+#include <cstdio>
+
+#include <search-worker/index/platform/platform_macros.h>
+#include <omp.h>
+
+#ifdef __SSE__
+#include <immintrin.h>
+#endif
+
+#include <search-worker/index/IndexIVF.h>
+#include <search-worker/index/impl/AuxIndexStructures.h>
+#include <search-worker/index/impl/IDSelector.h>
+#include <search-worker/index/utils/fp16.h>
+#include <search-worker/index/utils/utils.h>
+
+namespace faiss {
+
+/*******************************************************************
+ * ScalarQuantizer implementation
+ *
+ * The main source of complexity is to support combinations of 4
+ * variants without incurring runtime tests or virtual function calls:
+ *
+ * - 4 / 8 bits per code component
+ * - uniform / non-uniform
+ * - IP / L2 distance search
+ * - scalar / AVX distance computation
+ *
+ * The appropriate Quantizer object is returned via select_quantizer
+ * that hides the template mess.
+ ********************************************************************/
+
+#ifdef __AVX2__
+#ifdef __F16C__
+#define USE_F16C
+#else
+#warning \
+        "Cannot enable AVX optimizations in scalar quantizer if -mf16c is not set as well"
+#endif
+#endif
+
+namespace {
+
+typedef ScalarQuantizer::QuantizerType QuantizerType;
+typedef ScalarQuantizer::RangeStat RangeStat;
+using SQDistanceComputer = ScalarQuantizer::SQDistanceComputer;
+
+/*******************************************************************
+ * Codec: converts between values in [0, 1] and an index in a code
+ * array. The "i" parameter is the vector component index (not byte
+ * index).
+ */
+
+struct Codec8bit {
+    static FAISS_ALWAYS_INLINE void encode_component(
+            float x,
+            uint8_t* code,
+            int i) {
+        code[i] = (int)(255 * x);
+    }
+
+    static FAISS_ALWAYS_INLINE float decode_component(
+            const uint8_t* code,
+            int i) {
+        return (code[i] + 0.5f) / 255.0f;
+    }
+
+#ifdef __AVX2__
+    static FAISS_ALWAYS_INLINE __m256
+    decode_8_components(const uint8_t* code, int i) {
+        const uint64_t c8 = *(uint64_t*)(code + i);
+
+        const __m128i i8 = _mm_set1_epi64x(c8);
+        const __m256i i32 = _mm256_cvtepu8_epi32(i8);
+        const __m256 f8 = _mm256_cvtepi32_ps(i32);
+        const __m256 half_one_255 = _mm256_set1_ps(0.5f / 255.f);
+        const __m256 one_255 = _mm256_set1_ps(1.f / 255.f);
+        return _mm256_fmadd_ps(f8, one_255, half_one_255);
+    }
+#endif
+
+#ifdef __aarch64__
+    static FAISS_ALWAYS_INLINE float32x4x2_t
+    decode_8_components(const uint8_t* code, int i) {
+        float32_t result[8] = {};
+        for (size_t j = 0; j < 8; j++) {
+            result[j] = decode_component(code, i + j);
+        }
+        float32x4_t res1 = vld1q_f32(result);
+        float32x4_t res2 = vld1q_f32(result + 4);
+        float32x4x2_t res = vzipq_f32(res1, res2);
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+#endif
+};
+
+struct Codec4bit {
+    static FAISS_ALWAYS_INLINE void encode_component(
+            float x,
+            uint8_t* code,
+            int i) {
+        code[i / 2] |= (int)(x * 15.0) << ((i & 1) << 2);
+    }
+
+    static FAISS_ALWAYS_INLINE float decode_component(
+            const uint8_t* code,
+            int i) {
+        return (((code[i / 2] >> ((i & 1) << 2)) & 0xf) + 0.5f) / 15.0f;
+    }
+
+#ifdef __AVX2__
+    static FAISS_ALWAYS_INLINE __m256
+    decode_8_components(const uint8_t* code, int i) {
+        uint32_t c4 = *(uint32_t*)(code + (i >> 1));
+        uint32_t mask = 0x0f0f0f0f;
+        uint32_t c4ev = c4 & mask;
+        uint32_t c4od = (c4 >> 4) & mask;
+
+        // the 8 lower bytes of c8 contain the values
+        __m128i c8 =
+                _mm_unpacklo_epi8(_mm_set1_epi32(c4ev), _mm_set1_epi32(c4od));
+        __m128i c4lo = _mm_cvtepu8_epi32(c8);
+        __m128i c4hi = _mm_cvtepu8_epi32(_mm_srli_si128(c8, 4));
+        __m256i i8 = _mm256_castsi128_si256(c4lo);
+        i8 = _mm256_insertf128_si256(i8, c4hi, 1);
+        __m256 f8 = _mm256_cvtepi32_ps(i8);
+        __m256 half = _mm256_set1_ps(0.5f);
+        f8 = _mm256_add_ps(f8, half);
+        __m256 one_255 = _mm256_set1_ps(1.f / 15.f);
+        return _mm256_mul_ps(f8, one_255);
+    }
+#endif
+
+#ifdef __aarch64__
+    static FAISS_ALWAYS_INLINE float32x4x2_t
+    decode_8_components(const uint8_t* code, int i) {
+        float32_t result[8] = {};
+        for (size_t j = 0; j < 8; j++) {
+            result[j] = decode_component(code, i + j);
+        }
+        float32x4_t res1 = vld1q_f32(result);
+        float32x4_t res2 = vld1q_f32(result + 4);
+        float32x4x2_t res = vzipq_f32(res1, res2);
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+#endif
+};
+
+struct Codec6bit {
+    static FAISS_ALWAYS_INLINE void encode_component(
+            float x,
+            uint8_t* code,
+            int i) {
+        int bits = (int)(x * 63.0);
+        code += (i >> 2) * 3;
+        switch (i & 3) {
+            case 0:
+                code[0] |= bits;
+                break;
+            case 1:
+                code[0] |= bits << 6;
+                code[1] |= bits >> 2;
+                break;
+            case 2:
+                code[1] |= bits << 4;
+                code[2] |= bits >> 4;
+                break;
+            case 3:
+                code[2] |= bits << 2;
+                break;
+        }
+    }
+
+    static FAISS_ALWAYS_INLINE float decode_component(
+            const uint8_t* code,
+            int i) {
+        uint8_t bits;
+        code += (i >> 2) * 3;
+        switch (i & 3) {
+            case 0:
+                bits = code[0] & 0x3f;
+                break;
+            case 1:
+                bits = code[0] >> 6;
+                bits |= (code[1] & 0xf) << 2;
+                break;
+            case 2:
+                bits = code[1] >> 4;
+                bits |= (code[2] & 3) << 4;
+                break;
+            case 3:
+                bits = code[2] >> 2;
+                break;
+        }
+        return (bits + 0.5f) / 63.0f;
+    }
+
+#ifdef __AVX2__
+
+    /* Load 6 bytes that represent 8 6-bit values, return them as a
+     * 8*32 bit vector register */
+    static FAISS_ALWAYS_INLINE __m256i load6(const uint16_t* code16) {
+        const __m128i perm = _mm_set_epi8(
+                -1, 5, 5, 4, 4, 3, -1, 3, -1, 2, 2, 1, 1, 0, -1, 0);
+        const __m256i shifts = _mm256_set_epi32(2, 4, 6, 0, 2, 4, 6, 0);
+
+        // load 6 bytes
+        __m128i c1 =
+                _mm_set_epi16(0, 0, 0, 0, 0, code16[2], code16[1], code16[0]);
+
+        // put in 8 * 32 bits
+        __m128i c2 = _mm_shuffle_epi8(c1, perm);
+        __m256i c3 = _mm256_cvtepi16_epi32(c2);
+
+        // shift and mask out useless bits
+        __m256i c4 = _mm256_srlv_epi32(c3, shifts);
+        __m256i c5 = _mm256_and_si256(_mm256_set1_epi32(63), c4);
+        return c5;
+    }
+
+    static FAISS_ALWAYS_INLINE __m256
+    decode_8_components(const uint8_t* code, int i) {
+        // // Faster code for Intel CPUs or AMD Zen3+, just keeping it here
+        // // for the reference, maybe, it becomes used oned day.
+        // const uint16_t* data16 = (const uint16_t*)(code + (i >> 2) * 3);
+        // const uint32_t* data32 = (const uint32_t*)data16;
+        // const uint64_t val = *data32 + ((uint64_t)data16[2] << 32);
+        // const uint64_t vext = _pdep_u64(val, 0x3F3F3F3F3F3F3F3FULL);
+        // const __m128i i8 = _mm_set1_epi64x(vext);
+        // const __m256i i32 = _mm256_cvtepi8_epi32(i8);
+        // const __m256 f8 = _mm256_cvtepi32_ps(i32);
+        // const __m256 half_one_255 = _mm256_set1_ps(0.5f / 63.f);
+        // const __m256 one_255 = _mm256_set1_ps(1.f / 63.f);
+        // return _mm256_fmadd_ps(f8, one_255, half_one_255);
+
+        __m256i i8 = load6((const uint16_t*)(code + (i >> 2) * 3));
+        __m256 f8 = _mm256_cvtepi32_ps(i8);
+        // this could also be done with bit manipulations but it is
+        // not obviously faster
+        const __m256 half_one_255 = _mm256_set1_ps(0.5f / 63.f);
+        const __m256 one_255 = _mm256_set1_ps(1.f / 63.f);
+        return _mm256_fmadd_ps(f8, one_255, half_one_255);
+    }
+
+#endif
+
+#ifdef __aarch64__
+    static FAISS_ALWAYS_INLINE float32x4x2_t
+    decode_8_components(const uint8_t* code, int i) {
+        float32_t result[8] = {};
+        for (size_t j = 0; j < 8; j++) {
+            result[j] = decode_component(code, i + j);
+        }
+        float32x4_t res1 = vld1q_f32(result);
+        float32x4_t res2 = vld1q_f32(result + 4);
+        float32x4x2_t res = vzipq_f32(res1, res2);
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+#endif
+};
+
+/*******************************************************************
+ * Quantizer: normalizes scalar vector components, then passes them
+ * through a codec
+ *******************************************************************/
+
+template <class Codec, bool uniform, int SIMD>
+struct QuantizerTemplate {};
+
+template <class Codec>
+struct QuantizerTemplate<Codec, true, 1> : ScalarQuantizer::SQuantizer {
+    const size_t d;
+    const float vmin, vdiff;
+
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : d(d), vmin(trained[0]), vdiff(trained[1]) {}
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        for (size_t i = 0; i < d; i++) {
+            float xi = 0;
+            if (vdiff != 0) {
+                xi = (x[i] - vmin) / vdiff;
+                if (xi < 0) {
+                    xi = 0;
+                }
+                if (xi > 1.0) {
+                    xi = 1.0;
+                }
+            }
+            Codec::encode_component(xi, code, i);
+        }
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        for (size_t i = 0; i < d; i++) {
+            float xi = Codec::decode_component(code, i);
+            x[i] = vmin + xi * vdiff;
+        }
+    }
+
+    FAISS_ALWAYS_INLINE float reconstruct_component(const uint8_t* code, int i)
+            const {
+        float xi = Codec::decode_component(code, i);
+        return vmin + xi * vdiff;
+    }
+};
+
+#ifdef __AVX2__
+
+template <class Codec>
+struct QuantizerTemplate<Codec, true, 8> : QuantizerTemplate<Codec, true, 1> {
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : QuantizerTemplate<Codec, true, 1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE __m256
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        __m256 xi = Codec::decode_8_components(code, i);
+        return _mm256_fmadd_ps(
+                xi, _mm256_set1_ps(this->vdiff), _mm256_set1_ps(this->vmin));
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <class Codec>
+struct QuantizerTemplate<Codec, true, 8> : QuantizerTemplate<Codec, true, 1> {
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : QuantizerTemplate<Codec, true, 1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE float32x4x2_t
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        float32x4x2_t xi = Codec::decode_8_components(code, i);
+        float32x4x2_t res = vzipq_f32(
+                vfmaq_f32(
+                        vdupq_n_f32(this->vmin),
+                        xi.val[0],
+                        vdupq_n_f32(this->vdiff)),
+                vfmaq_f32(
+                        vdupq_n_f32(this->vmin),
+                        xi.val[1],
+                        vdupq_n_f32(this->vdiff)));
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+};
+
+#endif
+
+template <class Codec>
+struct QuantizerTemplate<Codec, false, 1> : ScalarQuantizer::SQuantizer {
+    const size_t d;
+    const float *vmin, *vdiff;
+
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : d(d), vmin(trained.data()), vdiff(trained.data() + d) {}
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        for (size_t i = 0; i < d; i++) {
+            float xi = 0;
+            if (vdiff[i] != 0) {
+                xi = (x[i] - vmin[i]) / vdiff[i];
+                if (xi < 0) {
+                    xi = 0;
+                }
+                if (xi > 1.0) {
+                    xi = 1.0;
+                }
+            }
+            Codec::encode_component(xi, code, i);
+        }
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        for (size_t i = 0; i < d; i++) {
+            float xi = Codec::decode_component(code, i);
+            x[i] = vmin[i] + xi * vdiff[i];
+        }
+    }
+
+    FAISS_ALWAYS_INLINE float reconstruct_component(const uint8_t* code, int i)
+            const {
+        float xi = Codec::decode_component(code, i);
+        return vmin[i] + xi * vdiff[i];
+    }
+};
+
+#ifdef __AVX2__
+
+template <class Codec>
+struct QuantizerTemplate<Codec, false, 8> : QuantizerTemplate<Codec, false, 1> {
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : QuantizerTemplate<Codec, false, 1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE __m256
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        __m256 xi = Codec::decode_8_components(code, i);
+        return _mm256_fmadd_ps(
+                xi,
+                _mm256_loadu_ps(this->vdiff + i),
+                _mm256_loadu_ps(this->vmin + i));
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <class Codec>
+struct QuantizerTemplate<Codec, false, 8> : QuantizerTemplate<Codec, false, 1> {
+    QuantizerTemplate(size_t d, const std::vector<float>& trained)
+            : QuantizerTemplate<Codec, false, 1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE float32x4x2_t
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        float32x4x2_t xi = Codec::decode_8_components(code, i);
+
+        float32x4x2_t vmin_8 = vld1q_f32_x2(this->vmin + i);
+        float32x4x2_t vdiff_8 = vld1q_f32_x2(this->vdiff + i);
+
+        float32x4x2_t res = vzipq_f32(
+                vfmaq_f32(vmin_8.val[0], xi.val[0], vdiff_8.val[0]),
+                vfmaq_f32(vmin_8.val[1], xi.val[1], vdiff_8.val[1]));
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+};
+
+#endif
+
+/*******************************************************************
+ * FP16 quantizer
+ *******************************************************************/
+
+template <int SIMDWIDTH>
+struct QuantizerFP16 {};
+
+template <>
+struct QuantizerFP16<1> : ScalarQuantizer::SQuantizer {
+    const size_t d;
+
+    QuantizerFP16(size_t d, const std::vector<float>& /* unused */) : d(d) {}
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        for (size_t i = 0; i < d; i++) {
+            ((uint16_t*)code)[i] = encode_fp16(x[i]);
+        }
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        for (size_t i = 0; i < d; i++) {
+            x[i] = decode_fp16(((uint16_t*)code)[i]);
+        }
+    }
+
+    FAISS_ALWAYS_INLINE float reconstruct_component(const uint8_t* code, int i)
+            const {
+        return decode_fp16(((uint16_t*)code)[i]);
+    }
+};
+
+#ifdef USE_F16C
+
+template <>
+struct QuantizerFP16<8> : QuantizerFP16<1> {
+    QuantizerFP16(size_t d, const std::vector<float>& trained)
+            : QuantizerFP16<1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE __m256
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        __m128i codei = _mm_loadu_si128((const __m128i*)(code + 2 * i));
+        return _mm256_cvtph_ps(codei);
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <>
+struct QuantizerFP16<8> : QuantizerFP16<1> {
+    QuantizerFP16(size_t d, const std::vector<float>& trained)
+            : QuantizerFP16<1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE float32x4x2_t
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        uint16x4x2_t codei = vld2_u16((const uint16_t*)(code + 2 * i));
+        return vzipq_f32(
+                vcvt_f32_f16(vreinterpret_f16_u16(codei.val[0])),
+                vcvt_f32_f16(vreinterpret_f16_u16(codei.val[1])));
+    }
+};
+#endif
+
+/*******************************************************************
+ * 8bit_direct quantizer
+ *******************************************************************/
+
+template <int SIMDWIDTH>
+struct Quantizer8bitDirect {};
+
+template <>
+struct Quantizer8bitDirect<1> : ScalarQuantizer::SQuantizer {
+    const size_t d;
+
+    Quantizer8bitDirect(size_t d, const std::vector<float>& /* unused */)
+            : d(d) {}
+
+    void encode_vector(const float* x, uint8_t* code) const final {
+        for (size_t i = 0; i < d; i++) {
+            code[i] = (uint8_t)x[i];
+        }
+    }
+
+    void decode_vector(const uint8_t* code, float* x) const final {
+        for (size_t i = 0; i < d; i++) {
+            x[i] = code[i];
+        }
+    }
+
+    FAISS_ALWAYS_INLINE float reconstruct_component(const uint8_t* code, int i)
+            const {
+        return code[i];
+    }
+};
+
+#ifdef __AVX2__
+
+template <>
+struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
+    Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
+            : Quantizer8bitDirect<1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE __m256
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        __m128i x8 = _mm_loadl_epi64((__m128i*)(code + i)); // 8 * int8
+        __m256i y8 = _mm256_cvtepu8_epi32(x8);              // 8 * int32
+        return _mm256_cvtepi32_ps(y8);                      // 8 * float32
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <>
+struct Quantizer8bitDirect<8> : Quantizer8bitDirect<1> {
+    Quantizer8bitDirect(size_t d, const std::vector<float>& trained)
+            : Quantizer8bitDirect<1>(d, trained) {}
+
+    FAISS_ALWAYS_INLINE float32x4x2_t
+    reconstruct_8_components(const uint8_t* code, int i) const {
+        float32_t result[8] = {};
+        for (size_t j = 0; j < 8; j++) {
+            result[j] = code[i + j];
+        }
+        float32x4_t res1 = vld1q_f32(result);
+        float32x4_t res2 = vld1q_f32(result + 4);
+        float32x4x2_t res = vzipq_f32(res1, res2);
+        return vuzpq_f32(res.val[0], res.val[1]);
+    }
+};
+
+#endif
+
+template <int SIMDWIDTH>
+ScalarQuantizer::SQuantizer* select_quantizer_1(
+        QuantizerType qtype,
+        size_t d,
+        const std::vector<float>& trained) {
+    switch (qtype) {
+        case ScalarQuantizer::QT_8bit:
+            return new QuantizerTemplate<Codec8bit, false, SIMDWIDTH>(
+                    d, trained);
+        case ScalarQuantizer::QT_6bit:
+            return new QuantizerTemplate<Codec6bit, false, SIMDWIDTH>(
+                    d, trained);
+        case ScalarQuantizer::QT_4bit:
+            return new QuantizerTemplate<Codec4bit, false, SIMDWIDTH>(
+                    d, trained);
+        case ScalarQuantizer::QT_8bit_uniform:
+            return new QuantizerTemplate<Codec8bit, true, SIMDWIDTH>(
+                    d, trained);
+        case ScalarQuantizer::QT_4bit_uniform:
+            return new QuantizerTemplate<Codec4bit, true, SIMDWIDTH>(
+                    d, trained);
+        case ScalarQuantizer::QT_fp16:
+            return new QuantizerFP16<SIMDWIDTH>(d, trained);
+        case ScalarQuantizer::QT_8bit_direct:
+            return new Quantizer8bitDirect<SIMDWIDTH>(d, trained);
+    }
+    // FAISS_THROW_MSG("unknown qtype");
+    assert(false);
+}
+
+/*******************************************************************
+ * Quantizer range training
+ */
+
+static float sqr(float x) {
+    return x * x;
+}
+
+void train_Uniform(
+        RangeStat rs,
+        float rs_arg,
+        idx_t n,
+        int k,
+        const float* x,
+        std::vector<float>& trained) {
+    trained.resize(2);
+    float& vmin = trained[0];
+    float& vmax = trained[1];
+
+    if (rs == ScalarQuantizer::RS_minmax) {
+        vmin = HUGE_VAL;
+        vmax = -HUGE_VAL;
+        for (size_t i = 0; i < n; i++) {
+            if (x[i] < vmin)
+                vmin = x[i];
+            if (x[i] > vmax)
+                vmax = x[i];
+        }
+        float vexp = (vmax - vmin) * rs_arg;
+        vmin -= vexp;
+        vmax += vexp;
+    } else if (rs == ScalarQuantizer::RS_meanstd) {
+        double sum = 0, sum2 = 0;
+        for (size_t i = 0; i < n; i++) {
+            sum += x[i];
+            sum2 += x[i] * x[i];
+        }
+        float mean = sum / n;
+        float var = sum2 / n - mean * mean;
+        float std = var <= 0 ? 1.0 : sqrt(var);
+
+        vmin = mean - std * rs_arg;
+        vmax = mean + std * rs_arg;
+    } else if (rs == ScalarQuantizer::RS_quantiles) {
+        std::vector<float> x_copy(n);
+        memcpy(x_copy.data(), x, n * sizeof(*x));
+        // TODO just do a quickselect
+        std::sort(x_copy.begin(), x_copy.end());
+        int o = int(rs_arg * n);
+        if (o < 0)
+            o = 0;
+        if (o > n - o)
+            o = n / 2;
+        vmin = x_copy[o];
+        vmax = x_copy[n - 1 - o];
+
+    } else if (rs == ScalarQuantizer::RS_optim) {
+        float a, b;
+        float sx = 0;
+        {
+            vmin = HUGE_VAL, vmax = -HUGE_VAL;
+            for (size_t i = 0; i < n; i++) {
+                if (x[i] < vmin)
+                    vmin = x[i];
+                if (x[i] > vmax)
+                    vmax = x[i];
+                sx += x[i];
+            }
+            b = vmin;
+            a = (vmax - vmin) / (k - 1);
+        }
+        int verbose = false;
+        int niter = 2000;
+        float last_err = -1;
+        int iter_last_err = 0;
+        for (int it = 0; it < niter; it++) {
+            float sn = 0, sn2 = 0, sxn = 0, err1 = 0;
+
+            for (idx_t i = 0; i < n; i++) {
+                float xi = x[i];
+                float ni = floor((xi - b) / a + 0.5);
+                if (ni < 0)
+                    ni = 0;
+                if (ni >= k)
+                    ni = k - 1;
+                err1 += sqr(xi - (ni * a + b));
+                sn += ni;
+                sn2 += ni * ni;
+                sxn += ni * xi;
+            }
+
+            if (err1 == last_err) {
+                iter_last_err++;
+                if (iter_last_err == 16)
+                    break;
+            } else {
+                last_err = err1;
+                iter_last_err = 0;
+            }
+
+            float det = sqr(sn) - sn2 * n;
+
+            b = (sn * sxn - sn2 * sx) / det;
+            a = (sn * sx - n * sxn) / det;
+            if (verbose) {
+                printf("it %d, err1=%g            \r", it, err1);
+                fflush(stdout);
+            }
+        }
+        if (verbose)
+            printf("\n");
+
+        vmin = b;
+        vmax = b + a * (k - 1);
+
+    } else {
+        // FAISS_THROW_MSG("Invalid qtype");
+        assert(false);
+    }
+    vmax -= vmin;
+}
+
+void train_NonUniform(
+        RangeStat rs,
+        float rs_arg,
+        idx_t n,
+        int d,
+        int k,
+        const float* x,
+        std::vector<float>& trained) {
+    trained.resize(2 * d);
+    float* vmin = trained.data();
+    float* vmax = trained.data() + d;
+    if (rs == ScalarQuantizer::RS_minmax) {
+        memcpy(vmin, x, sizeof(*x) * d);
+        memcpy(vmax, x, sizeof(*x) * d);
+        for (size_t i = 1; i < n; i++) {
+            const float* xi = x + i * d;
+            for (size_t j = 0; j < d; j++) {
+                if (xi[j] < vmin[j])
+                    vmin[j] = xi[j];
+                if (xi[j] > vmax[j])
+                    vmax[j] = xi[j];
+            }
+        }
+        float* vdiff = vmax;
+        for (size_t j = 0; j < d; j++) {
+            float vexp = (vmax[j] - vmin[j]) * rs_arg;
+            vmin[j] -= vexp;
+            vmax[j] += vexp;
+            vdiff[j] = vmax[j] - vmin[j];
+        }
+    } else {
+        // transpose
+        std::vector<float> xt(n * d);
+        for (size_t i = 1; i < n; i++) {
+            const float* xi = x + i * d;
+            for (size_t j = 0; j < d; j++) {
+                xt[j * n + i] = xi[j];
+            }
+        }
+        std::vector<float> trained_d(2);
+// #pragma omp parallel for
+        for (int j = 0; j < d; j++) {
+            train_Uniform(rs, rs_arg, n, k, xt.data() + j * n, trained_d);
+            vmin[j] = trained_d[0];
+            vmax[j] = trained_d[1];
+        }
+    }
+}
+
+/*******************************************************************
+ * Similarity: gets vector components and computes a similarity wrt. a
+ * query vector stored in the object. The data fields just encapsulate
+ * an accumulator.
+ */
+
+template <int SIMDWIDTH>
+struct SimilarityL2 {};
+
+template <>
+struct SimilarityL2<1> {
+    static constexpr int simdwidth = 1;
+    static constexpr MetricType metric_type = METRIC_L2;
+
+    const float *y, *yi;
+
+    explicit SimilarityL2(const float* y) : y(y) {}
+
+    /******* scalar accumulator *******/
+
+    float accu;
+
+    FAISS_ALWAYS_INLINE void begin() {
+        accu = 0;
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_component(float x) {
+        float tmp = *yi++ - x;
+        accu += tmp * tmp;
+    }
+
+    FAISS_ALWAYS_INLINE void add_component_2(float x1, float x2) {
+        float tmp = x1 - x2;
+        accu += tmp * tmp;
+    }
+
+    FAISS_ALWAYS_INLINE float result() {
+        return accu;
+    }
+};
+
+#ifdef __AVX2__
+template <>
+struct SimilarityL2<8> {
+    static constexpr int simdwidth = 8;
+    static constexpr MetricType metric_type = METRIC_L2;
+
+    const float *y, *yi;
+
+    explicit SimilarityL2(const float* y) : y(y) {}
+    __m256 accu8;
+
+    FAISS_ALWAYS_INLINE void begin_8() {
+        accu8 = _mm256_setzero_ps();
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components(__m256 x) {
+        __m256 yiv = _mm256_loadu_ps(yi);
+        yi += 8;
+        __m256 tmp = _mm256_sub_ps(yiv, x);
+        accu8 = _mm256_fmadd_ps(tmp, tmp, accu8);
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components_2(__m256 x, __m256 y_2) {
+        __m256 tmp = _mm256_sub_ps(y_2, x);
+        accu8 = _mm256_fmadd_ps(tmp, tmp, accu8);
+    }
+
+    FAISS_ALWAYS_INLINE float result_8() {
+        const __m128 sum = _mm_add_ps(
+                _mm256_castps256_ps128(accu8), _mm256_extractf128_ps(accu8, 1));
+        const __m128 v0 = _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(0, 0, 3, 2));
+        const __m128 v1 = _mm_add_ps(sum, v0);
+        __m128 v2 = _mm_shuffle_ps(v1, v1, _MM_SHUFFLE(0, 0, 0, 1));
+        const __m128 v3 = _mm_add_ps(v1, v2);
+        return _mm_cvtss_f32(v3);
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+template <>
+struct SimilarityL2<8> {
+    static constexpr int simdwidth = 8;
+    static constexpr MetricType metric_type = METRIC_L2;
+
+    const float *y, *yi;
+    explicit SimilarityL2(const float* y) : y(y) {}
+    float32x4x2_t accu8;
+
+    FAISS_ALWAYS_INLINE void begin_8() {
+        accu8 = vzipq_f32(vdupq_n_f32(0.0f), vdupq_n_f32(0.0f));
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components(float32x4x2_t x) {
+        float32x4x2_t yiv = vld1q_f32_x2(yi);
+        yi += 8;
+
+        float32x4_t sub0 = vsubq_f32(yiv.val[0], x.val[0]);
+        float32x4_t sub1 = vsubq_f32(yiv.val[1], x.val[1]);
+
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], sub0, sub0);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], sub1, sub1);
+
+        float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
+        accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components_2(
+            float32x4x2_t x,
+            float32x4x2_t y) {
+        float32x4_t sub0 = vsubq_f32(y.val[0], x.val[0]);
+        float32x4_t sub1 = vsubq_f32(y.val[1], x.val[1]);
+
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], sub0, sub0);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], sub1, sub1);
+
+        float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
+        accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
+    }
+
+    FAISS_ALWAYS_INLINE float result_8() {
+        float32x4_t sum_0 = vpaddq_f32(accu8.val[0], accu8.val[0]);
+        float32x4_t sum_1 = vpaddq_f32(accu8.val[1], accu8.val[1]);
+
+        float32x4_t sum2_0 = vpaddq_f32(sum_0, sum_0);
+        float32x4_t sum2_1 = vpaddq_f32(sum_1, sum_1);
+        return vgetq_lane_f32(sum2_0, 0) + vgetq_lane_f32(sum2_1, 0);
+    }
+};
+#endif
+
+template <int SIMDWIDTH>
+struct SimilarityIP {};
+
+template <>
+struct SimilarityIP<1> {
+    static constexpr int simdwidth = 1;
+    static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
+    const float *y, *yi;
+
+    float accu;
+
+    explicit SimilarityIP(const float* y) : y(y) {}
+
+    FAISS_ALWAYS_INLINE void begin() {
+        accu = 0;
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_component(float x) {
+        accu += *yi++ * x;
+    }
+
+    FAISS_ALWAYS_INLINE void add_component_2(float x1, float x2) {
+        accu += x1 * x2;
+    }
+
+    FAISS_ALWAYS_INLINE float result() {
+        return accu;
+    }
+};
+
+#ifdef __AVX2__
+
+template <>
+struct SimilarityIP<8> {
+    static constexpr int simdwidth = 8;
+    static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
+
+    const float *y, *yi;
+
+    float accu;
+
+    explicit SimilarityIP(const float* y) : y(y) {}
+
+    __m256 accu8;
+
+    FAISS_ALWAYS_INLINE void begin_8() {
+        accu8 = _mm256_setzero_ps();
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components(__m256 x) {
+        __m256 yiv = _mm256_loadu_ps(yi);
+        yi += 8;
+        accu8 = _mm256_fmadd_ps(yiv, x, accu8);
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components_2(__m256 x1, __m256 x2) {
+        accu8 = _mm256_fmadd_ps(x1, x2, accu8);
+    }
+
+    FAISS_ALWAYS_INLINE float result_8() {
+        const __m128 sum = _mm_add_ps(
+                _mm256_castps256_ps128(accu8), _mm256_extractf128_ps(accu8, 1));
+        const __m128 v0 = _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(0, 0, 3, 2));
+        const __m128 v1 = _mm_add_ps(sum, v0);
+        __m128 v2 = _mm_shuffle_ps(v1, v1, _MM_SHUFFLE(0, 0, 0, 1));
+        const __m128 v3 = _mm_add_ps(v1, v2);
+        return _mm_cvtss_f32(v3);
+    }
+};
+#endif
+
+#ifdef __aarch64__
+
+template <>
+struct SimilarityIP<8> {
+    static constexpr int simdwidth = 8;
+    static constexpr MetricType metric_type = METRIC_INNER_PRODUCT;
+
+    const float *y, *yi;
+
+    explicit SimilarityIP(const float* y) : y(y) {}
+    float32x4x2_t accu8;
+
+    FAISS_ALWAYS_INLINE void begin_8() {
+        accu8 = vzipq_f32(vdupq_n_f32(0.0f), vdupq_n_f32(0.0f));
+        yi = y;
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components(float32x4x2_t x) {
+        float32x4x2_t yiv = vld1q_f32_x2(yi);
+        yi += 8;
+
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], yiv.val[0], x.val[0]);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], yiv.val[1], x.val[1]);
+        float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
+        accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
+    }
+
+    FAISS_ALWAYS_INLINE void add_8_components_2(
+            float32x4x2_t x1,
+            float32x4x2_t x2) {
+        float32x4_t accu8_0 = vfmaq_f32(accu8.val[0], x1.val[0], x2.val[0]);
+        float32x4_t accu8_1 = vfmaq_f32(accu8.val[1], x1.val[1], x2.val[1]);
+        float32x4x2_t accu8_temp = vzipq_f32(accu8_0, accu8_1);
+        accu8 = vuzpq_f32(accu8_temp.val[0], accu8_temp.val[1]);
+    }
+
+    FAISS_ALWAYS_INLINE float result_8() {
+        float32x4x2_t sum_tmp = vzipq_f32(
+                vpaddq_f32(accu8.val[0], accu8.val[0]),
+                vpaddq_f32(accu8.val[1], accu8.val[1]));
+        float32x4x2_t sum = vuzpq_f32(sum_tmp.val[0], sum_tmp.val[1]);
+        float32x4x2_t sum2_tmp = vzipq_f32(
+                vpaddq_f32(sum.val[0], sum.val[0]),
+                vpaddq_f32(sum.val[1], sum.val[1]));
+        float32x4x2_t sum2 = vuzpq_f32(sum2_tmp.val[0], sum2_tmp.val[1]);
+        return vgetq_lane_f32(sum2.val[0], 0) + vgetq_lane_f32(sum2.val[1], 0);
+    }
+};
+#endif
+
+/*******************************************************************
+ * DistanceComputer: combines a similarity and a quantizer to do
+ * code-to-vector or code-to-code comparisons
+ *******************************************************************/
+
+template <class Quantizer, class Similarity, int SIMDWIDTH>
+struct DCTemplate : SQDistanceComputer {};
+
+template <class Quantizer, class Similarity>
+struct DCTemplate<Quantizer, Similarity, 1> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    Quantizer quant;
+
+    DCTemplate(size_t d, const std::vector<float>& trained)
+            : quant(d, trained) {}
+
+    float compute_distance(const float* x, const uint8_t* code) const {
+        Similarity sim(x);
+        sim.begin();
+        for (size_t i = 0; i < quant.d; i++) {
+            float xi = quant.reconstruct_component(code, i);
+            sim.add_component(xi);
+        }
+        return sim.result();
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        Similarity sim(nullptr);
+        sim.begin();
+        for (size_t i = 0; i < quant.d; i++) {
+            float x1 = quant.reconstruct_component(code1, i);
+            float x2 = quant.reconstruct_component(code2, i);
+            sim.add_component_2(x1, x2);
+        }
+        return sim.result();
+    }
+
+    void set_query(const float* x) final {
+        q = x;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_distance(q, code);
+    }
+};
+
+#ifdef USE_F16C
+
+template <class Quantizer, class Similarity>
+struct DCTemplate<Quantizer, Similarity, 8> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    Quantizer quant;
+
+    DCTemplate(size_t d, const std::vector<float>& trained)
+            : quant(d, trained) {}
+
+    float compute_distance(const float* x, const uint8_t* code) const {
+        Similarity sim(x);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            __m256 xi = quant.reconstruct_8_components(code, i);
+            sim.add_8_components(xi);
+        }
+        return sim.result_8();
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        Similarity sim(nullptr);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            __m256 x1 = quant.reconstruct_8_components(code1, i);
+            __m256 x2 = quant.reconstruct_8_components(code2, i);
+            sim.add_8_components_2(x1, x2);
+        }
+        return sim.result_8();
+    }
+
+    void set_query(const float* x) final {
+        q = x;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_distance(q, code);
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <class Quantizer, class Similarity>
+struct DCTemplate<Quantizer, Similarity, 8> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    Quantizer quant;
+
+    DCTemplate(size_t d, const std::vector<float>& trained)
+            : quant(d, trained) {}
+    float compute_distance(const float* x, const uint8_t* code) const {
+        Similarity sim(x);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            float32x4x2_t xi = quant.reconstruct_8_components(code, i);
+            sim.add_8_components(xi);
+        }
+        return sim.result_8();
+    }
+
+    float compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        Similarity sim(nullptr);
+        sim.begin_8();
+        for (size_t i = 0; i < quant.d; i += 8) {
+            float32x4x2_t x1 = quant.reconstruct_8_components(code1, i);
+            float32x4x2_t x2 = quant.reconstruct_8_components(code2, i);
+            sim.add_8_components_2(x1, x2);
+        }
+        return sim.result_8();
+    }
+
+    void set_query(const float* x) final {
+        q = x;
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_distance(q, code);
+    }
+};
+#endif
+
+/*******************************************************************
+ * DistanceComputerByte: computes distances in the integer domain
+ *******************************************************************/
+
+template <class Similarity, int SIMDWIDTH>
+struct DistanceComputerByte : SQDistanceComputer {};
+
+template <class Similarity>
+struct DistanceComputerByte<Similarity, 1> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    int d;
+    std::vector<uint8_t> tmp;
+
+    DistanceComputerByte(int d, const std::vector<float>&) : d(d), tmp(d) {}
+
+    int compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        int accu = 0;
+        for (int i = 0; i < d; i++) {
+            if (Sim::metric_type == METRIC_INNER_PRODUCT) {
+                accu += int(code1[i]) * code2[i];
+            } else {
+                int diff = int(code1[i]) - code2[i];
+                accu += diff * diff;
+            }
+        }
+        return accu;
+    }
+
+    void set_query(const float* x) final {
+        for (int i = 0; i < d; i++) {
+            tmp[i] = int(x[i]);
+        }
+    }
+
+    int compute_distance(const float* x, const uint8_t* code) {
+        set_query(x);
+        return compute_code_distance(tmp.data(), code);
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_code_distance(tmp.data(), code);
+    }
+};
+
+#ifdef __AVX2__
+
+template <class Similarity>
+struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    int d;
+    std::vector<uint8_t> tmp;
+
+    DistanceComputerByte(int d, const std::vector<float>&) : d(d), tmp(d) {}
+
+    int compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        // __m256i accu = _mm256_setzero_ps ();
+        __m256i accu = _mm256_setzero_si256();
+        for (int i = 0; i < d; i += 16) {
+            // load 16 bytes, convert to 16 uint16_t
+            __m256i c1 = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128((__m128i*)(code1 + i)));
+            __m256i c2 = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128((__m128i*)(code2 + i)));
+            __m256i prod32;
+            if (Sim::metric_type == METRIC_INNER_PRODUCT) {
+                prod32 = _mm256_madd_epi16(c1, c2);
+            } else {
+                __m256i diff = _mm256_sub_epi16(c1, c2);
+                prod32 = _mm256_madd_epi16(diff, diff);
+            }
+            accu = _mm256_add_epi32(accu, prod32);
+        }
+        __m128i sum = _mm256_extractf128_si256(accu, 0);
+        sum = _mm_add_epi32(sum, _mm256_extractf128_si256(accu, 1));
+        sum = _mm_hadd_epi32(sum, sum);
+        sum = _mm_hadd_epi32(sum, sum);
+        return _mm_cvtsi128_si32(sum);
+    }
+
+    void set_query(const float* x) final {
+        /*
+        for (int i = 0; i < d; i += 8) {
+            __m256 xi = _mm256_loadu_ps (x + i);
+            __m256i ci = _mm256_cvtps_epi32(xi);
+        */
+        for (int i = 0; i < d; i++) {
+            // tmp[i] = int(x[i]);
+            tmp[i] = uint8_t(x[i]*127+128);
+        }
+    }
+
+    int compute_distance(const float* x, const uint8_t* code) {
+        set_query(x);
+        return compute_code_distance(tmp.data(), code);
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_code_distance(tmp.data(), code);
+    }
+};
+
+#endif
+
+#ifdef __aarch64__
+
+template <class Similarity>
+struct DistanceComputerByte<Similarity, 8> : SQDistanceComputer {
+    using Sim = Similarity;
+
+    int d;
+    std::vector<uint8_t> tmp;
+
+    DistanceComputerByte(int d, const std::vector<float>&) : d(d), tmp(d) {}
+
+    int compute_code_distance(const uint8_t* code1, const uint8_t* code2)
+            const {
+        int accu = 0;
+        for (int i = 0; i < d; i++) {
+            if (Sim::metric_type == METRIC_INNER_PRODUCT) {
+                accu += int(code1[i]) * code2[i];
+            } else {
+                int diff = int(code1[i]) - code2[i];
+                accu += diff * diff;
+            }
+        }
+        return accu;
+    }
+
+    void set_query(const float* x) final {
+        for (int i = 0; i < d; i++) {
+            tmp[i] = int(x[i]);
+        }
+    }
+
+    int compute_distance(const float* x, const uint8_t* code) {
+        set_query(x);
+        return compute_code_distance(tmp.data(), code);
+    }
+
+    float symmetric_dis(idx_t i, idx_t j) override {
+        return compute_code_distance(
+                codes + i * code_size, codes + j * code_size);
+    }
+
+    float query_to_code(const uint8_t* code) const final {
+        return compute_code_distance(tmp.data(), code);
+    }
+};
+
+#endif
+
+/*******************************************************************
+ * select_distance_computer: runtime selection of template
+ * specialization
+ *******************************************************************/
+
+template <class Sim>
+SQDistanceComputer* select_distance_computer(
+        QuantizerType qtype,
+        size_t d,
+        const std::vector<float>& trained) {
+    constexpr int SIMDWIDTH = Sim::simdwidth;
+    switch (qtype) {
+        case ScalarQuantizer::QT_8bit_uniform:
+            return new DCTemplate<
+                    QuantizerTemplate<Codec8bit, true, SIMDWIDTH>,
+                    Sim,
+                    SIMDWIDTH>(d, trained);
+
+        case ScalarQuantizer::QT_4bit_uniform:
+            return new DCTemplate<
+                    QuantizerTemplate<Codec4bit, true, SIMDWIDTH>,
+                    Sim,
+                    SIMDWIDTH>(d, trained);
+
+        case ScalarQuantizer::QT_8bit:
+            return new DCTemplate<
+                    QuantizerTemplate<Codec8bit, false, SIMDWIDTH>,
+                    Sim,
+                    SIMDWIDTH>(d, trained);
+
+        case ScalarQuantizer::QT_6bit:
+            return new DCTemplate<
+                    QuantizerTemplate<Codec6bit, false, SIMDWIDTH>,
+                    Sim,
+                    SIMDWIDTH>(d, trained);
+
+        case ScalarQuantizer::QT_4bit:
+            return new DCTemplate<
+                    QuantizerTemplate<Codec4bit, false, SIMDWIDTH>,
+                    Sim,
+                    SIMDWIDTH>(d, trained);
+
+        case ScalarQuantizer::QT_fp16:
+            return new DCTemplate<QuantizerFP16<SIMDWIDTH>, Sim, SIMDWIDTH>(
+                    d, trained);
+
+        case ScalarQuantizer::QT_8bit_direct:
+            if (d % 16 == 0) {
+                return new DistanceComputerByte<Sim, SIMDWIDTH>(d, trained);
+            } else {
+                return new DCTemplate<
+                        Quantizer8bitDirect<SIMDWIDTH>,
+                        Sim,
+                        SIMDWIDTH>(d, trained);
+            }
+    }
+    // FAISS_THROW_MSG("unknown qtype");
+    assert(false);
+    return nullptr;
+}
+
+} // anonymous namespace
+
+/*******************************************************************
+ * ScalarQuantizer implementation
+ ********************************************************************/
+
+ScalarQuantizer::ScalarQuantizer(size_t d, QuantizerType qtype)
+        : Quantizer(d), qtype(qtype) {
+    set_derived_sizes();
+}
+
+ScalarQuantizer::ScalarQuantizer() {}
+
+void ScalarQuantizer::set_derived_sizes() {
+    switch (qtype) {
+        case QT_8bit:
+        case QT_8bit_uniform:
+        case QT_8bit_direct:
+            code_size = d;
+            bits = 8;
+            break;
+        case QT_4bit:
+        case QT_4bit_uniform:
+            code_size = (d + 1) / 2;
+            bits = 4;
+            break;
+        case QT_6bit:
+            code_size = (d * 6 + 7) / 8;
+            bits = 6;
+            break;
+        case QT_fp16:
+            code_size = d * 2;
+            bits = 16;
+            break;
+    }
+}
+
+void ScalarQuantizer::train(size_t n, const float* x) {
+    int bit_per_dim = qtype == QT_4bit_uniform ? 4
+            : qtype == QT_4bit                 ? 4
+            : qtype == QT_6bit                 ? 6
+            : qtype == QT_8bit_uniform         ? 8
+            : qtype == QT_8bit                 ? 8
+                                               : -1;
+
+    switch (qtype) {
+        case QT_4bit_uniform:
+        case QT_8bit_uniform:
+            train_Uniform(
+                    rangestat,
+                    rangestat_arg,
+                    n * d,
+                    1 << bit_per_dim,
+                    x,
+                    trained);
+            break;
+        case QT_4bit:
+        case QT_8bit:
+        case QT_6bit:
+            train_NonUniform(
+                    rangestat,
+                    rangestat_arg,
+                    n,
+                    d,
+                    1 << bit_per_dim,
+                    x,
+                    trained);
+            break;
+        case QT_fp16:
+        case QT_8bit_direct:
+            // no training necessary
+            break;
+    }
+}
+
+ScalarQuantizer::SQuantizer* ScalarQuantizer::select_quantizer() const {
+#if defined(USE_F16C) || defined(__aarch64__)
+    if (d % 8 == 0) {
+        return select_quantizer_1<8>(qtype, d, trained);
+    } else
+#endif
+    {
+        return select_quantizer_1<1>(qtype, d, trained);
+    }
+}
+
+void ScalarQuantizer::compute_codes(const float* x, uint8_t* codes, size_t n)
+        const {
+    std::unique_ptr<SQuantizer> squant(select_quantizer());
+
+    memset(codes, 0, code_size * n);
+// #pragma omp parallel for
+    for (int64_t i = 0; i < n; i++)
+        squant->encode_vector(x + i * d, codes + i * code_size);
+}
+
+void ScalarQuantizer::decode(const uint8_t* codes, float* x, size_t n) const {
+    std::unique_ptr<SQuantizer> squant(select_quantizer());
+
+// #pragma omp parallel for
+    for (int64_t i = 0; i < n; i++)
+        squant->decode_vector(codes + i * code_size, x + i * d);
+}
+
+SQDistanceComputer* ScalarQuantizer::get_distance_computer(
+        MetricType metric) const {
+    // FAISS_THROW_IF_NOT(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
+    assert(metric == METRIC_L2 || metric == METRIC_INNER_PRODUCT);
+#if defined(USE_F16C) || defined(__aarch64__)
+    if (d % 8 == 0) {
+        if (metric == METRIC_L2) {
+            return select_distance_computer<SimilarityL2<8>>(qtype, d, trained);
+        } else {
+            return select_distance_computer<SimilarityIP<8>>(qtype, d, trained);
+        }
+    } else
+#endif
+    {
+        if (metric == METRIC_L2) {
+            return select_distance_computer<SimilarityL2<1>>(qtype, d, trained);
+        } else {
+            return select_distance_computer<SimilarityIP<1>>(qtype, d, trained);
+        }
+    }
+}
+
+/*******************************************************************
+ * IndexScalarQuantizer/IndexIVFScalarQuantizer scanner object
+ *
+ * It is an InvertedListScanner, but is designed to work with
+ * IndexScalarQuantizer as well.
+ ********************************************************************/
+
+namespace {
+
+template <class DCClass, int use_sel>
+struct IVFSQScannerIP : InvertedListScanner {
+    DCClass dc;
+    bool by_residual;
+
+    float accu0; /// added to all distances
+
+    IVFSQScannerIP(
+            int d,
+            const std::vector<float>& trained,
+            size_t code_size,
+            bool store_pairs,
+            const IDSelector* sel,
+            bool by_residual)
+            : dc(d, trained), by_residual(by_residual), accu0(0) {
+        this->store_pairs = store_pairs;
+        this->sel = sel;
+        this->code_size = code_size;
+        this->keep_max = true;
+    }
+
+    void set_query(const float* query) override {
+        dc.set_query(query);
+    }
+
+    void set_list(idx_t list_no, float coarse_dis) override {
+        this->list_no = list_no;
+        accu0 = by_residual ? coarse_dis : 0;
+    }
+
+    float distance_to_code(const uint8_t* code) const final {
+        return accu0 + dc.query_to_code(code);
+    }
+
+    size_t scan_codes(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float* simi,
+            idx_t* idxi,
+            size_t k) const override {
+        size_t nup = 0;
+
+        for (size_t j = 0; j < list_size; j++, codes += code_size) {
+            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
+                continue;
+            }
+
+            float accu = accu0 + dc.query_to_code(codes);
+
+            if (accu > simi[0]) {
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
+                minheap_replace_top(k, simi, idxi, accu, id);
+                nup++;
+            }
+        }
+        return nup;
+    }
+
+    void scan_codes_range(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float radius,
+            RangeQueryResult& res) const override {
+        for (size_t j = 0; j < list_size; j++, codes += code_size) {
+            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
+                continue;
+            }
+
+            float accu = accu0 + dc.query_to_code(codes);
+            if (accu > radius) {
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
+                res.add(accu, id);
+            }
+        }
+    }
+};
+
+/* use_sel = 0: don't check selector
+ * = 1: check on ids[j]
+ * = 2: check in j directly (normally ids is nullptr and store_pairs)
+ */
+template <class DCClass, int use_sel>
+struct IVFSQScannerL2 : InvertedListScanner {
+    DCClass dc;
+
+    bool by_residual;
+    const Index* quantizer;
+    const float* x; /// current query
+
+    std::vector<float> tmp;
+
+    IVFSQScannerL2(
+            int d,
+            const std::vector<float>& trained,
+            size_t code_size,
+            const Index* quantizer,
+            bool store_pairs,
+            const IDSelector* sel,
+            bool by_residual)
+            : dc(d, trained),
+              by_residual(by_residual),
+              quantizer(quantizer),
+              x(nullptr),
+              tmp(d) {
+        this->store_pairs = store_pairs;
+        this->sel = sel;
+        this->code_size = code_size;
+    }
+
+    void set_query(const float* query) override {
+        x = query;
+        if (!quantizer) {
+            dc.set_query(query);
+        }
+    }
+
+    void set_list(idx_t list_no, float /*coarse_dis*/) override {
+        this->list_no = list_no;
+        if (by_residual) {
+            // shift of x_in wrt centroid
+            quantizer->compute_residual(x, tmp.data(), list_no);
+            dc.set_query(tmp.data());
+        } else {
+            dc.set_query(x);
+        }
+    }
+
+    float distance_to_code(const uint8_t* code) const final {
+        return dc.query_to_code(code);
+    }
+
+    size_t scan_codes(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float* simi,
+            idx_t* idxi,
+            size_t k) const override {
+        size_t nup = 0;
+        for (size_t j = 0; j < list_size; j++, codes += code_size) {
+            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
+                continue;
+            }
+
+            float dis = dc.query_to_code(codes);
+
+            if (dis < simi[0]) {
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
+                maxheap_replace_top(k, simi, idxi, dis, id);
+                nup++;
+            }
+        }
+        return nup;
+    }
+
+    void scan_codes_range(
+            size_t list_size,
+            const uint8_t* codes,
+            const idx_t* ids,
+            float radius,
+            RangeQueryResult& res) const override {
+        for (size_t j = 0; j < list_size; j++, codes += code_size) {
+            if (use_sel && !sel->is_member(use_sel == 1 ? ids[j] : j)) {
+                continue;
+            }
+
+            float dis = dc.query_to_code(codes);
+            if (dis < radius) {
+                int64_t id = store_pairs ? (list_no << 32 | j) : ids[j];
+                res.add(dis, id);
+            }
+        }
+    }
+};
+
+template <class DCClass, int use_sel>
+InvertedListScanner* sel3_InvertedListScanner(
+        const ScalarQuantizer* sq,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool r) {
+    if (DCClass::Sim::metric_type == METRIC_L2) {
+        return new IVFSQScannerL2<DCClass, use_sel>(
+                sq->d,
+                sq->trained,
+                sq->code_size,
+                quantizer,
+                store_pairs,
+                sel,
+                r);
+    } else if (DCClass::Sim::metric_type == METRIC_INNER_PRODUCT) {
+        return new IVFSQScannerIP<DCClass, use_sel>(
+                sq->d, sq->trained, sq->code_size, store_pairs, sel, r);
+    } else {
+        // FAISS_THROW_MSG("unsupported metric type");
+        assert(false);
+    }
+}
+
+template <class DCClass>
+InvertedListScanner* sel2_InvertedListScanner(
+        const ScalarQuantizer* sq,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool r) {
+    if (sel) {
+        if (store_pairs) {
+            return sel3_InvertedListScanner<DCClass, 2>(
+                    sq, quantizer, store_pairs, sel, r);
+        } else {
+            return sel3_InvertedListScanner<DCClass, 1>(
+                    sq, quantizer, store_pairs, sel, r);
+        }
+    } else {
+        return sel3_InvertedListScanner<DCClass, 0>(
+                sq, quantizer, store_pairs, sel, r);
+    }
+}
+
+template <class Similarity, class Codec, bool uniform>
+InvertedListScanner* sel12_InvertedListScanner(
+        const ScalarQuantizer* sq,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool r) {
+    constexpr int SIMDWIDTH = Similarity::simdwidth;
+    using QuantizerClass = QuantizerTemplate<Codec, uniform, SIMDWIDTH>;
+    using DCClass = DCTemplate<QuantizerClass, Similarity, SIMDWIDTH>;
+    return sel2_InvertedListScanner<DCClass>(
+            sq, quantizer, store_pairs, sel, r);
+}
+
+template <class Similarity>
+InvertedListScanner* sel1_InvertedListScanner(
+        const ScalarQuantizer* sq,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool r) {
+    constexpr int SIMDWIDTH = Similarity::simdwidth;
+    switch (sq->qtype) {
+        case ScalarQuantizer::QT_8bit_uniform:
+            return sel12_InvertedListScanner<Similarity, Codec8bit, true>(
+                    sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_4bit_uniform:
+            return sel12_InvertedListScanner<Similarity, Codec4bit, true>(
+                    sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_8bit:
+            return sel12_InvertedListScanner<Similarity, Codec8bit, false>(
+                    sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_4bit:
+            return sel12_InvertedListScanner<Similarity, Codec4bit, false>(
+                    sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_6bit:
+            return sel12_InvertedListScanner<Similarity, Codec6bit, false>(
+                    sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_fp16:
+            return sel2_InvertedListScanner<DCTemplate<
+                    QuantizerFP16<SIMDWIDTH>,
+                    Similarity,
+                    SIMDWIDTH>>(sq, quantizer, store_pairs, sel, r);
+        case ScalarQuantizer::QT_8bit_direct:
+            if (sq->d % 16 == 0) {
+                return sel2_InvertedListScanner<
+                        DistanceComputerByte<Similarity, SIMDWIDTH>>(
+                        sq, quantizer, store_pairs, sel, r);
+            } else {
+                return sel2_InvertedListScanner<DCTemplate<
+                        Quantizer8bitDirect<SIMDWIDTH>,
+                        Similarity,
+                        SIMDWIDTH>>(sq, quantizer, store_pairs, sel, r);
+            }
+    }
+
+    // FAISS_THROW_MSG("unknown qtype");
+    assert(false);
+    return nullptr;
+}
+
+template <int SIMDWIDTH>
+InvertedListScanner* sel0_InvertedListScanner(
+        MetricType mt,
+        const ScalarQuantizer* sq,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool by_residual) {
+    if (mt == METRIC_L2) {
+        return sel1_InvertedListScanner<SimilarityL2<SIMDWIDTH>>(
+                sq, quantizer, store_pairs, sel, by_residual);
+    } else if (mt == METRIC_INNER_PRODUCT) {
+        return sel1_InvertedListScanner<SimilarityIP<SIMDWIDTH>>(
+                sq, quantizer, store_pairs, sel, by_residual);
+    } else {
+        // FAISS_THROW_MSG("unsupported metric type");
+        assert(false);
+    }
+}
+
+} // anonymous namespace
+
+InvertedListScanner* ScalarQuantizer::select_InvertedListScanner(
+        MetricType mt,
+        const Index* quantizer,
+        bool store_pairs,
+        const IDSelector* sel,
+        bool by_residual) const {
+#if defined(USE_F16C) || defined(__aarch64__)
+    if (d % 8 == 0) {
+        return sel0_InvertedListScanner<8>(
+                mt, this, quantizer, store_pairs, sel, by_residual);
+    } else
+#endif
+    {
+        return sel0_InvertedListScanner<1>(
+                mt, this, quantizer, store_pairs, sel, by_residual);
+    }
+}
+
+} // namespace faiss

--- a/search-worker/index/impl/ScalarQuantizer.h
+++ b/search-worker/index/impl/ScalarQuantizer.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// -*- c++ -*-
+
+#pragma once
+
+#include <search-worker/index/impl/AuxIndexStructures.h>
+#include <search-worker/index/impl/DistanceComputer.h>
+#include <search-worker/index/impl/Quantizer.h>
+
+namespace faiss {
+
+struct InvertedListScanner;
+
+/**
+ * The uniform quantizer has a range [vmin, vmax]. The range can be
+ * the same for all dimensions (uniform) or specific per dimension
+ * (default).
+ */
+
+struct ScalarQuantizer : Quantizer {
+    enum QuantizerType {
+        QT_8bit,         ///< 8 bits per component
+        QT_4bit,         ///< 4 bits per component
+        QT_8bit_uniform, ///< same, shared range for all dimensions
+        QT_4bit_uniform,
+        QT_fp16,
+        QT_8bit_direct, ///< fast indexing of uint8s
+        QT_6bit,        ///< 6 bits per component
+    };
+
+    QuantizerType qtype = QT_8bit;
+
+    /** The uniform encoder can estimate the range of representable
+     * values of the unform encoder using different statistics. Here
+     * rs = rangestat_arg */
+
+    // rangestat_arg.
+    enum RangeStat {
+        RS_minmax,    ///< [min - rs*(max-min), max + rs*(max-min)]
+        RS_meanstd,   ///< [mean - std * rs, mean + std * rs]
+        RS_quantiles, ///< [Q(rs), Q(1-rs)]
+        RS_optim,     ///< alternate optimization of reconstruction error
+    };
+
+    RangeStat rangestat = RS_minmax;
+    float rangestat_arg = 0;
+
+    /// bits per scalar code
+    size_t bits = 0;
+
+    /// trained values (including the range)
+    std::vector<float> trained;
+
+    ScalarQuantizer(size_t d, QuantizerType qtype);
+    ScalarQuantizer();
+
+    /// updates internal values based on qtype and d
+    void set_derived_sizes();
+
+    void train(size_t n, const float* x) override;
+
+    /** Encode a set of vectors
+     *
+     * @param x      vectors to encode, size n * d
+     * @param codes  output codes, size n * code_size
+     */
+    void compute_codes(const float* x, uint8_t* codes, size_t n) const override;
+
+    /** Decode a set of vectors
+     *
+     * @param codes  codes to decode, size n * code_size
+     * @param x      output vectors, size n * d
+     */
+    void decode(const uint8_t* code, float* x, size_t n) const override;
+
+    /*****************************************************
+     * Objects that provide methods for encoding/decoding, distance
+     * computation and inverted list scanning
+     *****************************************************/
+
+    struct SQuantizer {
+        // encodes one vector. Assumes code is filled with 0s on input!
+        virtual void encode_vector(const float* x, uint8_t* code) const = 0;
+        virtual void decode_vector(const uint8_t* code, float* x) const = 0;
+
+        virtual ~SQuantizer() {}
+    };
+
+    SQuantizer* select_quantizer() const;
+
+    struct SQDistanceComputer : FlatCodesDistanceComputer {
+        const float* q;
+
+        SQDistanceComputer() : q(nullptr) {}
+
+        virtual float query_to_code(const uint8_t* code) const = 0;
+
+        float distance_to_code(const uint8_t* code) final {
+            return query_to_code(code);
+        }
+    };
+
+    SQDistanceComputer* get_distance_computer(
+            MetricType metric = METRIC_L2) const;
+
+    InvertedListScanner* select_InvertedListScanner(
+            MetricType mt,
+            const Index* quantizer,
+            bool store_pairs,
+            const IDSelector* sel,
+            bool by_residual = false) const;
+};
+
+} // namespace faiss

--- a/search-worker/index/impl/io.cpp
+++ b/search-worker/index/impl/io.cpp
@@ -16,19 +16,19 @@
 
 namespace faiss {
 
-/***********************************************************************
- * IO functions
- ***********************************************************************/
+// /***********************************************************************
+//  * IO functions
+//  ***********************************************************************/
 
-int IOReader::fileno() {
-    // FAISS_THROW_MSG("IOReader does not support memory mapping");
-    assert(!"IOReader does not support memory mapping");
-}
+// int IOReader::fileno() {
+//     // FAISS_THROW_MSG("IOReader does not support memory mapping");
+//     assert(!"IOReader does not support memory mapping");
+// }
 
-int IOWriter::fileno() {
-    // FAISS_THROW_MSG("IOWriter does not support memory mapping");
-    assert(!"IOWriter does not support memory mapping");
-}
+// int IOWriter::fileno() {
+//     // FAISS_THROW_MSG("IOWriter does not support memory mapping");
+//     assert(!"IOWriter does not support memory mapping");
+// }
 
 // /***********************************************************************
 //  * IO Vector

--- a/search-worker/index/impl/io.h
+++ b/search-worker/index/impl/io.h
@@ -25,42 +25,42 @@
 
 namespace faiss {
 
-struct IOReader {
-    // name that can be used in error messages
-    std::string name;
+// struct IOReader {
+//     // name that can be used in error messages
+//     std::string name;
 
-    // fread. Returns number of items read or 0 in case of EOF.
-    virtual size_t operator()(void* ptr, size_t size, size_t nitems) = 0;
+//     // fread. Returns number of items read or 0 in case of EOF.
+//     virtual size_t operator()(void* ptr, size_t size, size_t nitems) = 0;
 
-    // return a file number that can be memory-mapped
-    virtual int fileno();
+//     // return a file number that can be memory-mapped
+//     virtual int fileno();
 
-    virtual ~IOReader() {}
-};
+//     virtual ~IOReader() {}
+// };
 
-struct IOWriter {
-    // name that can be used in error messages
-    std::string name;
+// struct IOWriter {
+//     // name that can be used in error messages
+//     std::string name;
 
-    // fwrite. Return number of items written
-    virtual size_t operator()(const void* ptr, size_t size, size_t nitems) = 0;
+//     // fwrite. Return number of items written
+//     virtual size_t operator()(const void* ptr, size_t size, size_t nitems) = 0;
 
-    // return a file number that can be memory-mapped
-    virtual int fileno();
+//     // return a file number that can be memory-mapped
+//     virtual int fileno();
 
-    virtual ~IOWriter() noexcept(false) {}
-};
+//     virtual ~IOWriter() noexcept(false) {}
+// };
 
-struct VectorIOReader : IOReader {
-    std::vector<uint8_t> data;
-    size_t rp = 0;
-    size_t operator()(void* ptr, size_t size, size_t nitems) override;
-};
+// struct VectorIOReader : IOReader {
+//     std::vector<uint8_t> data;
+//     size_t rp = 0;
+//     size_t operator()(void* ptr, size_t size, size_t nitems) override;
+// };
 
-struct VectorIOWriter : IOWriter {
-    std::vector<uint8_t> data;
-    size_t operator()(const void* ptr, size_t size, size_t nitems) override;
-};
+// struct VectorIOWriter : IOWriter {
+//     std::vector<uint8_t> data;
+//     size_t operator()(const void* ptr, size_t size, size_t nitems) override;
+// };
 
 // struct FileIOReader : IOReader {
 //     FILE* f = nullptr;

--- a/search-worker/index/impl/io.h
+++ b/search-worker/index/impl/io.h
@@ -17,6 +17,7 @@
 #ifndef HAKES_SEARCHWORKER_INDEX_IMPL_IO_H_
 #define HAKES_SEARCHWORKER_INDEX_IMPL_IO_H_
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 #include <vector>

--- a/search-worker/index/utils/fp16-arm.h
+++ b/search-worker/index/utils/fp16-arm.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <arm_neon.h>
+#include <cstdint>
+
+namespace faiss {
+
+inline uint16_t encode_fp16(float x) {
+    float32x4_t fx4 = vdupq_n_f32(x);
+    float16x4_t f16x4 = vcvt_f16_f32(fx4);
+    uint16x4_t ui16x4 = vreinterpret_u16_f16(f16x4);
+    return vduph_lane_u16(ui16x4, 3);
+}
+
+inline float decode_fp16(uint16_t x) {
+    uint16x4_t ui16x4 = vdup_n_u16(x);
+    float16x4_t f16x4 = vreinterpret_f16_u16(ui16x4);
+    float32x4_t fx4 = vcvt_f32_f16(f16x4);
+    return vdups_laneq_f32(fx4, 3);
+}
+
+} // namespace faiss

--- a/search-worker/index/utils/fp16-fp16c.h
+++ b/search-worker/index/utils/fp16-fp16c.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <immintrin.h>
+#include <cstdint>
+
+namespace faiss {
+
+inline uint16_t encode_fp16(float x) {
+    __m128 xf = _mm_set1_ps(x);
+    __m128i xi =
+            _mm_cvtps_ph(xf, _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+    return _mm_cvtsi128_si32(xi) & 0xffff;
+}
+
+inline float decode_fp16(uint16_t x) {
+    __m128i xi = _mm_set1_epi16(x);
+    __m128 xf = _mm_cvtph_ps(xi);
+    return _mm_cvtss_f32(xf);
+}
+
+} // namespace faiss

--- a/search-worker/index/utils/fp16-inl.h
+++ b/search-worker/index/utils/fp16-inl.h
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace faiss {
+
+// non-intrinsic FP16 <-> FP32 code adapted from
+// https://github.com/ispc/ispc/blob/master/stdlib.ispc
+
+namespace {
+
+inline float floatbits(uint32_t x) {
+    void* xptr = &x;
+    return *(float*)xptr;
+}
+
+inline uint32_t intbits(float f) {
+    void* fptr = &f;
+    return *(uint32_t*)fptr;
+}
+
+} // namespace
+
+inline uint16_t encode_fp16(float f) {
+    // via Fabian "ryg" Giesen.
+    // https://gist.github.com/2156668
+    uint32_t sign_mask = 0x80000000u;
+    int32_t o;
+
+    uint32_t fint = intbits(f);
+    uint32_t sign = fint & sign_mask;
+    fint ^= sign;
+
+    // NOTE all the integer compares in this function can be safely
+    // compiled into signed compares since all operands are below
+    // 0x80000000. Important if you want fast straight SSE2 code (since
+    // there's no unsigned PCMPGTD).
+
+    // Inf or NaN (all exponent bits set)
+    // NaN->qNaN and Inf->Inf
+    // unconditional assignment here, will override with right value for
+    // the regular case below.
+    uint32_t f32infty = 255u << 23;
+    o = (fint > f32infty) ? 0x7e00u : 0x7c00u;
+
+    // (De)normalized number or zero
+    // update fint unconditionally to save the blending; we don't need it
+    // anymore for the Inf/NaN case anyway.
+
+    const uint32_t round_mask = ~0xfffu;
+    const uint32_t magic = 15u << 23;
+
+    // Shift exponent down, denormalize if necessary.
+    // NOTE This represents half-float denormals using single
+    // precision denormals.  The main reason to do this is that
+    // there's no shift with per-lane variable shifts in SSE*, which
+    // we'd otherwise need. It has some funky side effects though:
+    // - This conversion will actually respect the FTZ (Flush To Zero)
+    //   flag in MXCSR - if it's set, no half-float denormals will be
+    //   generated. I'm honestly not sure whether this is good or
+    //   bad. It's definitely interesting.
+    // - If the underlying HW doesn't support denormals (not an issue
+    //   with Intel CPUs, but might be a problem on GPUs or PS3 SPUs),
+    //   you will always get flush-to-zero behavior. This is bad,
+    //   unless you're on a CPU where you don't care.
+    // - Denormals tend to be slow. FP32 denormals are rare in
+    //   practice outside of things like recursive filters in DSP -
+    //   not a typical half-float application. Whether FP16 denormals
+    //   are rare in practice, I don't know. Whatever slow path your
+    //   HW may or may not have for denormals, this may well hit it.
+    float fscale = floatbits(fint & round_mask) * floatbits(magic);
+    fscale = std::min(fscale, floatbits((31u << 23) - 0x1000u));
+    int32_t fint2 = intbits(fscale) - round_mask;
+
+    if (fint < f32infty)
+        o = fint2 >> 13; // Take the bits!
+
+    return (o | (sign >> 16));
+}
+
+inline float decode_fp16(uint16_t h) {
+    // https://gist.github.com/2144712
+    // Fabian "ryg" Giesen.
+
+    const uint32_t shifted_exp = 0x7c00u << 13; // exponent mask after shift
+
+    int32_t o = ((int32_t)(h & 0x7fffu)) << 13; // exponent/mantissa bits
+    int32_t exp = shifted_exp & o;              // just the exponent
+    o += (int32_t)(127 - 15) << 23;             // exponent adjust
+
+    int32_t infnan_val = o + ((int32_t)(128 - 16) << 23);
+    int32_t zerodenorm_val =
+            intbits(floatbits(o + (1u << 23)) - floatbits(113u << 23));
+    int32_t reg_val = (exp == 0) ? zerodenorm_val : o;
+
+    int32_t sign_bit = ((int32_t)(h & 0x8000u)) << 16;
+    return floatbits(((exp == shifted_exp) ? infnan_val : reg_val) | sign_bit);
+}
+
+} // namespace faiss

--- a/search-worker/index/utils/fp16.h
+++ b/search-worker/index/utils/fp16.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <search-worker/index/platform/platform_macros.h>
+
+#if defined(__F16C__)
+#include <search-worker/index/utils/fp16-fp16c.h>
+#elif defined(__aarch64__)
+#include <search-worker/index/utils/fp16-arm.h>
+#else
+#include <search-worker/index/utils/fp16-inl.h>
+#endif

--- a/search-worker/index/utils/ordered_key_value.h
+++ b/search-worker/index/utils/ordered_key_value.h
@@ -12,6 +12,7 @@
 #include <cmath>
 
 #include <limits>
+#include <cstdint>
 
 namespace faiss {
 

--- a/search-worker/index/utils/partitioning.cpp
+++ b/search-worker/index/utils/partitioning.cpp
@@ -1,0 +1,1328 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <search-worker/index/utils/partitioning.h>
+
+#include <cassert>
+#include <cmath>
+
+// #include <faiss/impl/FaissAssert.h>
+#include <search-worker/index/utils/AlignedTable.h>
+#include <search-worker/index/utils/ordered_key_value.h>
+#include <search-worker/index/utils/simdlib.h>
+
+// #include <faiss/impl/platform_macros.h>
+
+namespace faiss {
+
+/******************************************************************
+ * Internal routines
+ ******************************************************************/
+
+namespace partitioning {
+
+template <typename T>
+T median3(T a, T b, T c) {
+    if (a > b) {
+        std::swap(a, b);
+    }
+    if (c > b) {
+        return b;
+    }
+    if (c > a) {
+        return c;
+    }
+    return a;
+}
+
+template <class C>
+typename C::T sample_threshold_median3(
+        const typename C::T* vals,
+        int n,
+        typename C::T thresh_inf,
+        typename C::T thresh_sup) {
+    using T = typename C::T;
+    size_t big_prime = 6700417;
+    T val3[3];
+    int vi = 0;
+
+    for (size_t i = 0; i < n; i++) {
+        T v = vals[(i * big_prime) % n];
+        // thresh_inf < v < thresh_sup (for CMax)
+        if (C::cmp(v, thresh_inf) && C::cmp(thresh_sup, v)) {
+            val3[vi++] = v;
+            if (vi == 3) {
+                break;
+            }
+        }
+    }
+
+    if (vi == 3) {
+        return median3(val3[0], val3[1], val3[2]);
+    } else if (vi != 0) {
+        return val3[0];
+    } else {
+        return thresh_inf;
+        //   FAISS_THROW_MSG("too few values to compute a median");
+    }
+}
+
+template <class C>
+void count_lt_and_eq(
+        const typename C::T* vals,
+        size_t n,
+        typename C::T thresh,
+        size_t& n_lt,
+        size_t& n_eq) {
+    n_lt = n_eq = 0;
+
+    for (size_t i = 0; i < n; i++) {
+        typename C::T v = *vals++;
+        if (C::cmp(thresh, v)) {
+            n_lt++;
+        } else if (v == thresh) {
+            n_eq++;
+        }
+    }
+}
+
+template <class C>
+size_t compress_array(
+        typename C::T* vals,
+        typename C::TI* ids,
+        size_t n,
+        typename C::T thresh,
+        size_t n_eq) {
+    size_t wp = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (C::cmp(thresh, vals[i])) {
+            vals[wp] = vals[i];
+            ids[wp] = ids[i];
+            wp++;
+        } else if (n_eq > 0 && vals[i] == thresh) {
+            vals[wp] = vals[i];
+            ids[wp] = ids[i];
+            wp++;
+            n_eq--;
+        }
+    }
+    assert(n_eq == 0);
+    return wp;
+}
+
+#define IFV if (false)
+
+template <class C>
+typename C::T partition_fuzzy_median3(
+        typename C::T* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out) {
+    if (q_min == 0) {
+        if (q_out) {
+            *q_out = C::Crev::neutral();
+        }
+        return 0;
+    }
+    if (q_max >= n) {
+        if (q_out) {
+            *q_out = q_max;
+        }
+        return C::neutral();
+    }
+
+    using T = typename C::T;
+
+    // here we use bissection with a median of 3 to find the threshold and
+    // compress the arrays afterwards. So it's a n*log(n) algoirithm rather than
+    // qselect's O(n) but it avoids shuffling around the array.
+
+    // FAISS_THROW_IF_NOT(n >= 3);
+    assert(n >= 3);
+
+    T thresh_inf = C::Crev::neutral();
+    T thresh_sup = C::neutral();
+    T thresh = median3(vals[0], vals[n / 2], vals[n - 1]);
+
+    size_t n_eq = 0, n_lt = 0;
+    size_t q = 0;
+
+    for (int it = 0; it < 200; it++) {
+        count_lt_and_eq<C>(vals, n, thresh, n_lt, n_eq);
+
+        IFV printf(
+                "   thresh=%g [%g %g] n_lt=%ld n_eq=%ld, q=%ld:%ld/%ld\n",
+                float(thresh),
+                float(thresh_inf),
+                float(thresh_sup),
+                long(n_lt),
+                long(n_eq),
+                long(q_min),
+                long(q_max),
+                long(n));
+
+        if (n_lt <= q_min) {
+            if (n_lt + n_eq >= q_min) {
+                q = q_min;
+                break;
+            } else {
+                thresh_inf = thresh;
+            }
+        } else if (n_lt <= q_max) {
+            q = n_lt;
+            break;
+        } else {
+            thresh_sup = thresh;
+        }
+
+        // FIXME avoid a second pass over the array to sample the threshold
+        IFV printf(
+                "     sample thresh in [%g %g]\n",
+                float(thresh_inf),
+                float(thresh_sup));
+        T new_thresh =
+                sample_threshold_median3<C>(vals, n, thresh_inf, thresh_sup);
+        if (new_thresh == thresh_inf) {
+            // then there is nothing between thresh_inf and thresh_sup
+            break;
+        }
+        thresh = new_thresh;
+    }
+
+    int64_t n_eq_1 = q - n_lt;
+
+    IFV printf("shrink: thresh=%g n_eq_1=%ld\n", float(thresh), long(n_eq_1));
+
+    if (n_eq_1 < 0) { // happens when > q elements are at lower bound
+        q = q_min;
+        thresh = C::Crev::nextafter(thresh);
+        n_eq_1 = q;
+    } else {
+        assert(n_eq_1 <= n_eq);
+    }
+
+    int wp = compress_array<C>(vals, ids, n, thresh, n_eq_1);
+
+    assert(wp == q);
+    if (q_out) {
+        *q_out = q;
+    }
+
+    return thresh;
+}
+
+} // namespace partitioning
+
+/******************************************************************
+ * SIMD routines when vals is an aligned array of uint16_t
+ ******************************************************************/
+
+namespace simd_partitioning {
+
+void find_minimax(
+        const uint16_t* vals,
+        size_t n,
+        uint16_t& smin,
+        uint16_t& smax) {
+    simd16uint16 vmin(0xffff), vmax(0);
+    for (size_t i = 0; i + 15 < n; i += 16) {
+        simd16uint16 v(vals + i);
+        vmin.accu_min(v);
+        vmax.accu_max(v);
+    }
+
+    ALIGNED(32) uint16_t tab32[32];
+    vmin.store(tab32);
+    vmax.store(tab32 + 16);
+
+    smin = tab32[0], smax = tab32[16];
+
+    for (int i = 1; i < 16; i++) {
+        smin = std::min(smin, tab32[i]);
+        smax = std::max(smax, tab32[i + 16]);
+    }
+
+    // missing values
+    for (size_t i = (n & ~15); i < n; i++) {
+        smin = std::min(smin, vals[i]);
+        smax = std::max(smax, vals[i]);
+    }
+}
+
+// max func differentiates between CMin and CMax (keep lowest or largest)
+template <class C>
+simd16uint16 max_func(simd16uint16 v, simd16uint16 thr16) {
+    constexpr bool is_max = C::is_max;
+    if (is_max) {
+        return max(v, thr16);
+    } else {
+        return min(v, thr16);
+    }
+}
+
+template <class C>
+void count_lt_and_eq(
+        const uint16_t* vals,
+        int n,
+        uint16_t thresh,
+        size_t& n_lt,
+        size_t& n_eq) {
+    n_lt = n_eq = 0;
+    simd16uint16 thr16(thresh);
+
+    size_t n1 = n / 16;
+
+    for (size_t i = 0; i < n1; i++) {
+        simd16uint16 v(vals);
+        vals += 16;
+        simd16uint16 eqmask = (v == thr16);
+        simd16uint16 max2 = max_func<C>(v, thr16);
+        simd16uint16 gemask = (v == max2);
+        uint32_t bits = get_MSBs(uint16_to_uint8_saturate(eqmask, gemask));
+        int i_eq = __builtin_popcount(bits & 0x00ff00ff);
+        int i_ge = __builtin_popcount(bits) - i_eq;
+        n_eq += i_eq;
+        n_lt += 16 - i_ge;
+    }
+
+    for (size_t i = n1 * 16; i < n; i++) {
+        uint16_t v = *vals++;
+        if (C::cmp(thresh, v)) {
+            n_lt++;
+        } else if (v == thresh) {
+            n_eq++;
+        }
+    }
+}
+
+/* compress separated values and ids table, keeping all values < thresh and at
+ * most n_eq equal values */
+template <class C>
+int simd_compress_array(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        uint16_t thresh,
+        int n_eq) {
+    simd16uint16 thr16(thresh);
+    simd16uint16 mixmask(0xff00);
+
+    int wp = 0;
+    size_t i0;
+
+    // loop while there are eqs to collect
+    for (i0 = 0; i0 + 15 < n && n_eq > 0; i0 += 16) {
+        simd16uint16 v(vals + i0);
+        simd16uint16 max2 = max_func<C>(v, thr16);
+        simd16uint16 gemask = (v == max2);
+        simd16uint16 eqmask = (v == thr16);
+        uint32_t bits = get_MSBs(
+                blendv(simd32uint8(eqmask),
+                       simd32uint8(gemask),
+                       simd32uint8(mixmask)));
+        bits ^= 0xAAAAAAAA;
+        // bit 2*i     : eq
+        // bit 2*i + 1 : lt
+
+        while (bits) {
+            int j = __builtin_ctz(bits) & (~1);
+            bool is_eq = (bits >> j) & 1;
+            bool is_lt = (bits >> j) & 2;
+            bits &= ~(3 << j);
+            j >>= 1;
+
+            if (is_lt) {
+                vals[wp] = vals[i0 + j];
+                ids[wp] = ids[i0 + j];
+                wp++;
+            } else if (is_eq && n_eq > 0) {
+                vals[wp] = vals[i0 + j];
+                ids[wp] = ids[i0 + j];
+                wp++;
+                n_eq--;
+            }
+        }
+    }
+
+    // handle remaining, only striclty lt ones.
+    for (; i0 + 15 < n; i0 += 16) {
+        simd16uint16 v(vals + i0);
+        simd16uint16 max2 = max_func<C>(v, thr16);
+        simd16uint16 gemask = (v == max2);
+        uint32_t bits = ~get_MSBs(simd32uint8(gemask));
+
+        while (bits) {
+            int j = __builtin_ctz(bits);
+            bits &= ~(3 << j);
+            j >>= 1;
+
+            vals[wp] = vals[i0 + j];
+            ids[wp] = ids[i0 + j];
+            wp++;
+        }
+    }
+
+    // end with scalar
+    for (int i = (n & ~15); i < n; i++) {
+        if (C::cmp(thresh, vals[i])) {
+            vals[wp] = vals[i];
+            ids[wp] = ids[i];
+            wp++;
+        } else if (vals[i] == thresh && n_eq > 0) {
+            vals[wp] = vals[i];
+            ids[wp] = ids[i];
+            wp++;
+            n_eq--;
+        }
+    }
+    assert(n_eq == 0);
+    return wp;
+}
+
+// #define MICRO_BENCHMARK
+
+static uint64_t get_cy() {
+#ifdef MICRO_BENCHMARK
+    uint32_t high, low;
+    asm volatile("rdtsc \n\t" : "=a"(low), "=d"(high));
+    return ((uint64_t)high << 32) | (low);
+#else
+    return 0;
+#endif
+}
+
+#define IFV if (false)
+
+template <class C>
+uint16_t simd_partition_fuzzy_with_bounds(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out,
+        uint16_t s0i,
+        uint16_t s1i) {
+    if (q_min == 0) {
+        if (q_out) {
+            *q_out = 0;
+        }
+        return 0;
+    }
+    if (q_max >= n) {
+        if (q_out) {
+            *q_out = q_max;
+        }
+        return 0xffff;
+    }
+    if (s0i == s1i) {
+        if (q_out) {
+            *q_out = q_min;
+        }
+        return s0i;
+    }
+    uint64_t t0 = get_cy();
+
+    // lower bound inclusive, upper exclusive
+    size_t s0 = s0i, s1 = s1i + 1;
+
+    IFV printf("bounds: %ld %ld\n", s0, s1 - 1);
+
+    int thresh;
+    size_t n_eq = 0, n_lt = 0;
+    size_t q = 0;
+
+    for (int it = 0; it < 200; it++) {
+        // while(s0 + 1 < s1) {
+        thresh = (s0 + s1) / 2;
+        count_lt_and_eq<C>(vals, n, thresh, n_lt, n_eq);
+
+        IFV printf(
+                "   [%ld %ld] thresh=%d n_lt=%ld n_eq=%ld, q=%ld:%ld/%ld\n",
+                s0,
+                s1,
+                thresh,
+                n_lt,
+                n_eq,
+                q_min,
+                q_max,
+                n);
+        if (n_lt <= q_min) {
+            if (n_lt + n_eq >= q_min) {
+                q = q_min;
+                break;
+            } else {
+                if (C::is_max) {
+                    s0 = thresh;
+                } else {
+                    s1 = thresh;
+                }
+            }
+        } else if (n_lt <= q_max) {
+            q = n_lt;
+            break;
+        } else {
+            if (C::is_max) {
+                s1 = thresh;
+            } else {
+                s0 = thresh;
+            }
+        }
+    }
+
+    uint64_t t1 = get_cy();
+
+    // number of equal values to keep
+    int64_t n_eq_1 = q - n_lt;
+
+    IFV printf("shrink: thresh=%d q=%ld n_eq_1=%ld\n", thresh, q, n_eq_1);
+    if (n_eq_1 < 0) { // happens when > q elements are at lower bound
+        assert(s0 + 1 == s1);
+        q = q_min;
+        if (C::is_max) {
+            thresh--;
+        } else {
+            thresh++;
+        }
+        n_eq_1 = q;
+        IFV printf("  override: thresh=%d n_eq_1=%ld\n", thresh, n_eq_1);
+    } else {
+        assert(n_eq_1 <= n_eq);
+    }
+
+    size_t wp = simd_compress_array<C>(vals, ids, n, thresh, n_eq_1);
+
+    IFV printf("wp=%ld\n", wp);
+    assert(wp == q);
+    if (q_out) {
+        *q_out = q;
+    }
+
+    uint64_t t2 = get_cy();
+
+    partition_stats.bissect_cycles += t1 - t0;
+    partition_stats.compress_cycles += t2 - t1;
+
+    return thresh;
+}
+
+template <class C>
+uint16_t simd_partition_fuzzy_with_bounds_histogram(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out,
+        uint16_t s0i,
+        uint16_t s1i) {
+    if (q_min == 0) {
+        if (q_out) {
+            *q_out = 0;
+        }
+        return 0;
+    }
+    if (q_max >= n) {
+        if (q_out) {
+            *q_out = q_max;
+        }
+        return 0xffff;
+    }
+    if (s0i == s1i) {
+        if (q_out) {
+            *q_out = q_min;
+        }
+        return s0i;
+    }
+
+    IFV printf(
+            "partition fuzzy, q=%ld:%ld / %ld, bounds=%d %d\n",
+            q_min,
+            q_max,
+            n,
+            s0i,
+            s1i);
+
+    if (!C::is_max) {
+        IFV printf(
+                "revert due to CMin, q_min:q_max -> %ld:%ld\n", q_min, q_max);
+        q_min = n - q_min;
+        q_max = n - q_max;
+    }
+
+    // lower and upper bound of range, inclusive
+    int s0 = s0i, s1 = s1i;
+    // number of values < s0 and > s1
+    size_t n_lt = 0, n_gt = 0;
+
+    // output of loop:
+    int thresh;          // final threshold
+    uint64_t tot_eq = 0; // total nb of equal values
+    uint64_t n_eq = 0;   // nb of equal values to keep
+    size_t q;            // final quantile
+
+    // buffer for the histograms
+    int hist[16];
+
+    for (int it = 0; it < 20; it++) {
+        // otherwise we would be done already
+
+        int shift = 0;
+
+        IFV printf(
+                "  it %d bounds: %d %d n_lt=%ld n_gt=%ld\n",
+                it,
+                s0,
+                s1,
+                n_lt,
+                n_gt);
+
+        int maxval = s1 - s0;
+
+        while (maxval > 15) {
+            shift++;
+            maxval >>= 1;
+        }
+
+        IFV printf(
+                "    histogram shift %d maxval %d ?= %d\n",
+                shift,
+                maxval,
+                int((s1 - s0) >> shift));
+
+        if (maxval > 7) {
+            simd_histogram_16(vals, n, s0, shift, hist);
+        } else {
+            simd_histogram_8(vals, n, s0, shift, hist);
+        }
+        IFV {
+            int sum = n_lt + n_gt;
+            printf("    n_lt=%ld hist=[", n_lt);
+            for (int i = 0; i <= maxval; i++) {
+                printf("%d ", hist[i]);
+                sum += hist[i];
+            }
+            printf("] n_gt=%ld sum=%d\n", n_gt, sum);
+            assert(sum == n);
+        }
+
+        size_t sum_below = n_lt;
+        int i;
+        for (i = 0; i <= maxval; i++) {
+            sum_below += hist[i];
+            if (sum_below >= q_min) {
+                break;
+            }
+        }
+        IFV printf("    i=%d sum_below=%ld\n", i, sum_below);
+        if (i <= maxval) {
+            s0 = s0 + (i << shift);
+            s1 = s0 + (1 << shift) - 1;
+            n_lt = sum_below - hist[i];
+            n_gt = n - sum_below;
+        } else {
+            assert(!"not implemented");
+        }
+
+        IFV printf(
+                "    new bin: s0=%d s1=%d n_lt=%ld n_gt=%ld\n",
+                s0,
+                s1,
+                n_lt,
+                n_gt);
+
+        if (s1 > s0) {
+            if (n_lt >= q_min && q_max >= n_lt) {
+                IFV printf("    FOUND1\n");
+                thresh = s0;
+                q = n_lt;
+                break;
+            }
+
+            size_t n_lt_2 = n - n_gt;
+            if (n_lt_2 >= q_min && q_max >= n_lt_2) {
+                thresh = s1 + 1;
+                q = n_lt_2;
+                IFV printf("    FOUND2\n");
+                break;
+            }
+        } else {
+            thresh = s0;
+            q = q_min;
+            tot_eq = n - n_gt - n_lt;
+            n_eq = q_min - n_lt;
+            IFV printf("    FOUND3\n");
+            break;
+        }
+    }
+
+    IFV printf("end bissection: thresh=%d q=%ld n_eq=%ld\n", thresh, q, n_eq);
+
+    if (!C::is_max) {
+        if (n_eq == 0) {
+            thresh--;
+        } else {
+            // thresh unchanged
+            n_eq = tot_eq - n_eq;
+        }
+        q = n - q;
+        IFV printf("revert due to CMin, q->%ld n_eq->%ld\n", q, n_eq);
+    }
+
+    size_t wp = simd_compress_array<C>(vals, ids, n, thresh, n_eq);
+    IFV printf("wp=%ld ?= %ld\n", wp, q);
+    assert(wp == q);
+    if (q_out) {
+        *q_out = wp;
+    }
+
+    return thresh;
+}
+
+template <class C>
+uint16_t simd_partition_fuzzy(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out) {
+    assert(is_aligned_pointer(vals));
+
+    uint16_t s0i, s1i;
+    find_minimax(vals, n, s0i, s1i);
+    // QSelect_stats.t0 += get_cy() - t0;
+
+    return simd_partition_fuzzy_with_bounds<C>(
+            vals, ids, n, q_min, q_max, q_out, s0i, s1i);
+}
+
+template <class C>
+uint16_t simd_partition(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q) {
+    assert(is_aligned_pointer(vals));
+
+    if (q == 0) {
+        return 0;
+    }
+    if (q >= n) {
+        return 0xffff;
+    }
+
+    uint16_t s0i, s1i;
+    find_minimax(vals, n, s0i, s1i);
+
+    return simd_partition_fuzzy_with_bounds<C>(
+            vals, ids, n, q, q, nullptr, s0i, s1i);
+}
+
+template <class C>
+uint16_t simd_partition_with_bounds(
+        uint16_t* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q,
+        uint16_t s0i,
+        uint16_t s1i) {
+    return simd_partition_fuzzy_with_bounds<C>(
+            vals, ids, n, q, q, nullptr, s0i, s1i);
+}
+
+} // namespace simd_partitioning
+
+/******************************************************************
+ * Driver routine
+ ******************************************************************/
+
+template <class C>
+typename C::T partition_fuzzy(
+        typename C::T* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out) {
+#ifdef __AVX2__
+    constexpr bool is_uint16 = std::is_same<typename C::T, uint16_t>::value;
+    if (is_uint16 && is_aligned_pointer(vals)) {
+        return simd_partitioning::simd_partition_fuzzy<C>(
+                (uint16_t*)vals, ids, n, q_min, q_max, q_out);
+    }
+#endif
+    return partitioning::partition_fuzzy_median3<C>(
+            vals, ids, n, q_min, q_max, q_out);
+}
+
+// explicit template instanciations
+
+template float partition_fuzzy<CMin<float, int64_t>>(
+        float* vals,
+        int64_t* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+template float partition_fuzzy<CMax<float, int64_t>>(
+        float* vals,
+        int64_t* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+template uint16_t partition_fuzzy<CMin<uint16_t, int64_t>>(
+        uint16_t* vals,
+        int64_t* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+template uint16_t partition_fuzzy<CMax<uint16_t, int64_t>>(
+        uint16_t* vals,
+        int64_t* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+template uint16_t partition_fuzzy<CMin<uint16_t, int>>(
+        uint16_t* vals,
+        int* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+template uint16_t partition_fuzzy<CMax<uint16_t, int>>(
+        uint16_t* vals,
+        int* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+/******************************************************************
+ * Histogram subroutines
+ ******************************************************************/
+
+#if defined(__AVX2__) || defined(__aarch64__)
+/// FIXME when MSB of uint16 is set
+// this code does not compile properly with GCC 7.4.0
+
+namespace {
+
+/************************************************************
+ * 8 bins
+ ************************************************************/
+
+simd32uint8 accu4to8(simd16uint16 a4) {
+    simd16uint16 mask4(0x0f0f);
+
+    simd16uint16 a8_0 = a4 & mask4;
+    simd16uint16 a8_1 = (a4 >> 4) & mask4;
+
+    return simd32uint8(hadd(a8_0, a8_1));
+}
+
+simd16uint16 accu8to16(simd32uint8 a8) {
+    simd16uint16 mask8(0x00ff);
+
+    simd16uint16 a8_0 = simd16uint16(a8) & mask8;
+    simd16uint16 a8_1 = (simd16uint16(a8) >> 8) & mask8;
+
+    return hadd(a8_0, a8_1);
+}
+
+static const simd32uint8 shifts = simd32uint8::create<
+        1,
+        16,
+        0,
+        0,
+        4,
+        64,
+        0,
+        0,
+        0,
+        0,
+        1,
+        16,
+        0,
+        0,
+        4,
+        64,
+        1,
+        16,
+        0,
+        0,
+        4,
+        64,
+        0,
+        0,
+        0,
+        0,
+        1,
+        16,
+        0,
+        0,
+        4,
+        64>();
+
+// 2-bit accumulator: we can add only up to 3 elements
+// on output we return 2*4-bit results
+// preproc returns either an index in 0..7 or 0xffff
+// that yields a 0 when used in the table look-up
+template <int N, class Preproc>
+void compute_accu2(
+        const uint16_t*& data,
+        Preproc& pp,
+        simd16uint16& a4lo,
+        simd16uint16& a4hi) {
+    simd16uint16 mask2(0x3333);
+    simd16uint16 a2((uint16_t)0); // 2-bit accu
+    for (int j = 0; j < N; j++) {
+        simd16uint16 v(data);
+        data += 16;
+        v = pp(v);
+        // 0x800 -> force second half of table
+        simd16uint16 idx = v | (v << 8) | simd16uint16(0x800);
+        a2 += simd16uint16(shifts.lookup_2_lanes(simd32uint8(idx)));
+    }
+    a4lo += a2 & mask2;
+    a4hi += (a2 >> 2) & mask2;
+}
+
+template <class Preproc>
+simd16uint16 histogram_8(const uint16_t* data, Preproc pp, size_t n_in) {
+    assert(n_in % 16 == 0);
+    int n = n_in / 16;
+
+    simd32uint8 a8lo(0);
+    simd32uint8 a8hi(0);
+
+    for (int i0 = 0; i0 < n; i0 += 15) {
+        simd16uint16 a4lo(0); // 4-bit accus
+        simd16uint16 a4hi(0);
+
+        int i1 = std::min(i0 + 15, n);
+        int i;
+        for (i = i0; i + 2 < i1; i += 3) {
+            compute_accu2<3>(data, pp, a4lo, a4hi); // adds 3 max
+        }
+        switch (i1 - i) {
+            case 2:
+                compute_accu2<2>(data, pp, a4lo, a4hi);
+                break;
+            case 1:
+                compute_accu2<1>(data, pp, a4lo, a4hi);
+                break;
+        }
+
+        a8lo += accu4to8(a4lo);
+        a8hi += accu4to8(a4hi);
+    }
+
+    // move to 16-bit accu
+    simd16uint16 a16lo = accu8to16(a8lo);
+    simd16uint16 a16hi = accu8to16(a8hi);
+
+    simd16uint16 a16 = hadd(a16lo, a16hi);
+
+    // the 2 lanes must still be combined
+    return a16;
+}
+
+/************************************************************
+ * 16 bins
+ ************************************************************/
+
+static const simd32uint8 shifts2 = simd32uint8::create<
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128>();
+
+simd32uint8 shiftr_16(simd32uint8 x, int n) {
+    return simd32uint8(simd16uint16(x) >> n);
+}
+
+// 2-bit accumulator: we can add only up to 3 elements
+// on output we return 2*4-bit results
+template <int N, class Preproc>
+void compute_accu2_16(
+        const uint16_t*& data,
+        Preproc pp,
+        simd32uint8& a4_0,
+        simd32uint8& a4_1,
+        simd32uint8& a4_2,
+        simd32uint8& a4_3) {
+    simd32uint8 mask1(0x55);
+    simd32uint8 a2_0; // 2-bit accu
+    simd32uint8 a2_1; // 2-bit accu
+    a2_0.clear();
+    a2_1.clear();
+
+    for (int j = 0; j < N; j++) {
+        simd16uint16 v(data);
+        data += 16;
+        v = pp(v);
+
+        simd16uint16 idx = v | (v << 8);
+        simd32uint8 a1 = shifts2.lookup_2_lanes(simd32uint8(idx));
+        // contains 0s for out-of-bounds elements
+
+        simd16uint16 lt8 = (v >> 3) == simd16uint16(0);
+        lt8 = lt8 ^ simd16uint16(0xff00);
+
+        a1 = a1 & lt8;
+
+        a2_0 += a1 & mask1;
+        a2_1 += shiftr_16(a1, 1) & mask1;
+    }
+    simd32uint8 mask2(0x33);
+
+    a4_0 += a2_0 & mask2;
+    a4_1 += a2_1 & mask2;
+    a4_2 += shiftr_16(a2_0, 2) & mask2;
+    a4_3 += shiftr_16(a2_1, 2) & mask2;
+}
+
+simd32uint8 accu4to8_2(simd32uint8 a4_0, simd32uint8 a4_1) {
+    simd32uint8 mask4(0x0f);
+
+    simd16uint16 a8_0 = combine2x2(
+            (simd16uint16)(a4_0 & mask4),
+            (simd16uint16)(shiftr_16(a4_0, 4) & mask4));
+
+    simd16uint16 a8_1 = combine2x2(
+            (simd16uint16)(a4_1 & mask4),
+            (simd16uint16)(shiftr_16(a4_1, 4) & mask4));
+
+    return simd32uint8(hadd(a8_0, a8_1));
+}
+
+template <class Preproc>
+simd16uint16 histogram_16(const uint16_t* data, Preproc pp, size_t n_in) {
+    assert(n_in % 16 == 0);
+    int n = n_in / 16;
+
+    simd32uint8 a8lo((uint8_t)0);
+    simd32uint8 a8hi((uint8_t)0);
+
+    for (int i0 = 0; i0 < n; i0 += 7) {
+        simd32uint8 a4_0(0); // 0, 4, 8, 12
+        simd32uint8 a4_1(0); // 1, 5, 9, 13
+        simd32uint8 a4_2(0); // 2, 6, 10, 14
+        simd32uint8 a4_3(0); // 3, 7, 11, 15
+
+        int i1 = std::min(i0 + 7, n);
+        int i;
+        for (i = i0; i + 2 < i1; i += 3) {
+            compute_accu2_16<3>(data, pp, a4_0, a4_1, a4_2, a4_3);
+        }
+        switch (i1 - i) {
+            case 2:
+                compute_accu2_16<2>(data, pp, a4_0, a4_1, a4_2, a4_3);
+                break;
+            case 1:
+                compute_accu2_16<1>(data, pp, a4_0, a4_1, a4_2, a4_3);
+                break;
+        }
+
+        a8lo += accu4to8_2(a4_0, a4_1);
+        a8hi += accu4to8_2(a4_2, a4_3);
+    }
+
+    // move to 16-bit accu
+    simd16uint16 a16lo = accu8to16(a8lo);
+    simd16uint16 a16hi = accu8to16(a8hi);
+
+    simd16uint16 a16 = hadd(a16lo, a16hi);
+
+    a16 = simd16uint16{simd8uint32{a16}.unzip()};
+
+    return a16;
+}
+
+struct PreprocNOP {
+    simd16uint16 operator()(simd16uint16 x) {
+        return x;
+    }
+};
+
+template <int shift, int nbin>
+struct PreprocMinShift {
+    simd16uint16 min16;
+    simd16uint16 max16;
+
+    explicit PreprocMinShift(uint16_t min) {
+        min16.set1(min);
+        int vmax0 = std::min((nbin << shift) + min, 65536);
+        uint16_t vmax = uint16_t(vmax0 - 1 - min);
+        max16.set1(vmax); // vmax inclusive
+    }
+
+    simd16uint16 operator()(simd16uint16 x) {
+        x = x - min16;
+        simd16uint16 mask = (x == max(x, max16)) - (x == max16);
+        return (x >> shift) | mask;
+    }
+};
+
+/* unbounded versions of the functions */
+
+void simd_histogram_8_unbounded(const uint16_t* data, int n, int* hist) {
+    PreprocNOP pp;
+    simd16uint16 a16 = histogram_8(data, pp, (n & ~15));
+
+    ALIGNED(32) uint16_t a16_tab[16];
+    a16.store(a16_tab);
+
+    for (int i = 0; i < 8; i++) {
+        hist[i] = a16_tab[i] + a16_tab[i + 8];
+    }
+
+    for (int i = (n & ~15); i < n; i++) {
+        hist[data[i]]++;
+    }
+}
+
+void simd_histogram_16_unbounded(const uint16_t* data, int n, int* hist) {
+    simd16uint16 a16 = histogram_16(data, PreprocNOP(), (n & ~15));
+
+    ALIGNED(32) uint16_t a16_tab[16];
+    a16.store(a16_tab);
+
+    for (int i = 0; i < 16; i++) {
+        hist[i] = a16_tab[i];
+    }
+
+    for (int i = (n & ~15); i < n; i++) {
+        hist[data[i]]++;
+    }
+}
+
+} // anonymous namespace
+
+/************************************************************
+ * Driver routines
+ ************************************************************/
+
+void simd_histogram_8(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist) {
+    if (shift < 0) {
+        simd_histogram_8_unbounded(data, n, hist);
+        return;
+    }
+
+    simd16uint16 a16;
+
+#define DISPATCH(s)                                                     \
+    case s:                                                             \
+        a16 = histogram_8(data, PreprocMinShift<s, 8>(min), (n & ~15)); \
+        break
+
+    switch (shift) {
+        DISPATCH(0);
+        DISPATCH(1);
+        DISPATCH(2);
+        DISPATCH(3);
+        DISPATCH(4);
+        DISPATCH(5);
+        DISPATCH(6);
+        DISPATCH(7);
+        DISPATCH(8);
+        DISPATCH(9);
+        DISPATCH(10);
+        DISPATCH(11);
+        DISPATCH(12);
+        DISPATCH(13);
+        default:
+            // FAISS_THROW_FMT("dispatch for shift=%d not instantiated", shift);
+            assert(!"dispatch for shift not instantiated");
+    }
+#undef DISPATCH
+
+    ALIGNED(32) uint16_t a16_tab[16];
+    a16.store(a16_tab);
+
+    for (int i = 0; i < 8; i++) {
+        hist[i] = a16_tab[i] + a16_tab[i + 8];
+    }
+
+    // complete with remaining bins
+    for (int i = (n & ~15); i < n; i++) {
+        if (data[i] < min)
+            continue;
+        uint16_t v = data[i] - min;
+        v >>= shift;
+        if (v < 8)
+            hist[v]++;
+    }
+}
+
+void simd_histogram_16(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist) {
+    if (shift < 0) {
+        simd_histogram_16_unbounded(data, n, hist);
+        return;
+    }
+
+    simd16uint16 a16;
+
+#define DISPATCH(s)                                                       \
+    case s:                                                               \
+        a16 = histogram_16(data, PreprocMinShift<s, 16>(min), (n & ~15)); \
+        break
+
+    switch (shift) {
+        DISPATCH(0);
+        DISPATCH(1);
+        DISPATCH(2);
+        DISPATCH(3);
+        DISPATCH(4);
+        DISPATCH(5);
+        DISPATCH(6);
+        DISPATCH(7);
+        DISPATCH(8);
+        DISPATCH(9);
+        DISPATCH(10);
+        DISPATCH(11);
+        DISPATCH(12);
+        default:
+            // FAISS_THROW_FMT("dispatch for shift=%d not instantiated", shift);
+            assert(!"dispatch for shift not instantiated");
+    }
+#undef DISPATCH
+
+    ALIGNED(32) uint16_t a16_tab[16];
+    a16.store(a16_tab);
+
+    for (int i = 0; i < 16; i++) {
+        hist[i] = a16_tab[i];
+    }
+
+    for (int i = (n & ~15); i < n; i++) {
+        if (data[i] < min)
+            continue;
+        uint16_t v = data[i] - min;
+        v >>= shift;
+        if (v < 16)
+            hist[v]++;
+    }
+}
+
+// no AVX2
+#else
+
+void simd_histogram_16(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist) {
+    memset(hist, 0, sizeof(*hist) * 16);
+    if (shift < 0) {
+        for (size_t i = 0; i < n; i++) {
+            hist[data[i]]++;
+        }
+    } else {
+        int vmax0 = std::min((16 << shift) + min, 65536);
+        uint16_t vmax = uint16_t(vmax0 - 1 - min);
+
+        for (size_t i = 0; i < n; i++) {
+            uint16_t v = data[i];
+            v -= min;
+            if (!(v <= vmax))
+                continue;
+            v >>= shift;
+            hist[v]++;
+
+            /*
+            if (data[i] < min) continue;
+            uint16_t v = data[i] - min;
+            v >>= shift;
+            if (v < 16) hist[v]++;
+            */
+        }
+    }
+}
+
+void simd_histogram_8(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist) {
+    memset(hist, 0, sizeof(*hist) * 8);
+    if (shift < 0) {
+        for (size_t i = 0; i < n; i++) {
+            hist[data[i]]++;
+        }
+    } else {
+        for (size_t i = 0; i < n; i++) {
+            if (data[i] < min)
+                continue;
+            uint16_t v = data[i] - min;
+            v >>= shift;
+            if (v < 8)
+                hist[v]++;
+        }
+    }
+}
+
+#endif
+
+void PartitionStats::reset() {
+    memset(this, 0, sizeof(*this));
+}
+
+PartitionStats partition_stats;
+
+} // namespace faiss

--- a/search-worker/index/utils/partitioning.h
+++ b/search-worker/index/utils/partitioning.h
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef HAKES_SEARCHWORKER_INDEX_UTILS_PARTITIONING_H_
+#define HAKES_SEARCHWORKER_INDEX_UTILS_PARTITIONING_H_
+
+#include <stdint.h>
+#include <stdio.h>
+
+// #include <faiss/impl/platform_macros.h>
+
+namespace faiss {
+
+/** partitions the table into 0:q and q:n where all elements above q are >= all
+ * elements below q (for C = CMax, for CMin comparisons are reversed)
+ *
+ * Returns the partition threshold. The elements q:n are destroyed on output.
+ */
+template <class C>
+typename C::T partition_fuzzy(
+        typename C::T* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q_min,
+        size_t q_max,
+        size_t* q_out);
+
+/** simplified interface for when the parition is not fuzzy */
+template <class C>
+inline typename C::T partition(
+        typename C::T* vals,
+        typename C::TI* ids,
+        size_t n,
+        size_t q) {
+    return partition_fuzzy<C>(vals, ids, n, q, q, nullptr);
+}
+
+/** low level SIMD histogramming functions */
+
+/** 8-bin histogram of (x - min) >> shift
+ * values outside the range are ignored.
+ * the data table should be aligned on 32 bytes */
+void simd_histogram_8(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist);
+
+/** same for 16-bin histogram */
+void simd_histogram_16(
+        const uint16_t* data,
+        int n,
+        uint16_t min,
+        int shift,
+        int* hist);
+
+struct PartitionStats {
+    uint64_t bissect_cycles;
+    uint64_t compress_cycles;
+
+    PartitionStats() {
+        reset();
+    }
+    void reset();
+};
+
+// global var that collects them all
+extern PartitionStats partition_stats;
+
+} // namespace faiss
+
+#endif  // HAKES_SEARCHWORKER_INDEX_UTILS_PARTITIONING_H_

--- a/search-worker/src/common/worker.cc
+++ b/search-worker/src/common/worker.cc
@@ -20,17 +20,17 @@
 
 #include "message/keyservice_worker.h"
 #include "message/searchservice.h"
-#include "ratls-channel/common/channel_client.h"
 #include "search-worker/common/workerImpl.h"
 #include "search-worker/index/ext/IndexFlatL.h"
 #include "search-worker/index/ext/IndexIVFPQFastScanL.h"
-#include "search-worker/index/ext/index_io_ext.h"
 #include "utils/base64.h"
 #include "utils/cache.h"
 #include "utils/hexutil.h"
+#include "utils/io.h"
 
 #ifdef USE_SGX
 #include "Enclave_t.h"
+#include "ratls-channel/common/channel_client.h"
 #include "utils/tcrypto_ext.h"
 #endif  // USE_SGX
 
@@ -211,12 +211,12 @@ std::string encode_hex_floats(const float* vecs, size_t count) {
 
 namespace search_worker {
 
-bool WorkerImpl::Initialize(const char* index_data, size_t index_len,
+bool WorkerImpl::Initialize(hakes::IOReader* ff, hakes::IOReader* rf,
+                            hakes::IOReader* uf, bool keep_pa,
                             int cluster_size, int server_id) {
   // index_.reset(new faiss::IndexFlatL(4, faiss::METRIC_INNER_PRODUCT));
   index_.reset(new faiss::HakesIndex());
-  faiss::StringIOReader reader(index_data, index_len);
-  index_->Initialize(&reader, false);
+  index_->Initialize(ff, rf, uf, keep_pa);
   index_->base_index_->use_balanced_assign_ = false;
   cluster_size_ = cluster_size;
   server_id_ = server_id;

--- a/search-worker/src/no-sgx/app.cc
+++ b/search-worker/src/no-sgx/app.cc
@@ -94,7 +94,8 @@ int main(int argc, char* argv[]) {
       hakes::ReadFileToCharArray(cfg.index_path.c_str(), &content_len);
   printf("content_len: %ld\n", content_len);
 
-  bool status = worker.Initialize(content.get(), content_len, 1, 0);
+  auto r = hakes::StringIOReader(content.get(), content_len);
+  bool status = worker.Initialize(&r, nullptr, nullptr, false, 1, 0);
   if (!status) {
     printf("Failed to initialize\n");
     exit(1);
@@ -134,8 +135,7 @@ int main(int argc, char* argv[]) {
   // search the first vector
   hakes::SearchWorkerSearchRequest search_req;
   search_req.d = cfg.data_dim;
-  search_req.vecs =
-      hakes::encode_hex_floats(query, cfg.data_dim);
+  search_req.vecs = hakes::encode_hex_floats(query, cfg.data_dim);
   search_req.k = cfg.search_k;
   search_req.nprobe = cfg.nprobe;
   search_req.k_factor = cfg.k_factor;
@@ -156,7 +156,8 @@ int main(int argc, char* argv[]) {
 
   // decode the search result
   hakes::SearchWorkerSearchResponse search_resp;
-  status = hakes::decode_search_worker_search_response(resp.get(), &search_resp);
+  status =
+      hakes::decode_search_worker_search_response(resp.get(), &search_resp);
   if (!status) {
     printf("Failed to decode search result\n");
     exit(1);
@@ -183,7 +184,7 @@ int main(int argc, char* argv[]) {
   auto resp_rerank = std::unique_ptr<char[]>(new char[4096 * 4096]);
   status = worker.Rerank(encoded_rerank_req.c_str(), encoded_rerank_req.size(),
                          resp_rerank.get(), 4096 * 4096);
-  
+
   if (status) {
     printf("Output: %s\n", resp_rerank.get());
   } else {
@@ -193,7 +194,8 @@ int main(int argc, char* argv[]) {
 
   // decode the rerank result
   hakes::SearchWorkerRerankResponse rerank_resp;
-  status = hakes::decode_search_worker_rerank_response(resp_rerank.get(), &rerank_resp);
+  status = hakes::decode_search_worker_rerank_response(resp_rerank.get(),
+                                                       &rerank_resp);
 
   if (!status) {
     printf("Failed to decode rerank result\n");

--- a/search-worker/src/no-sgx/app3.cc
+++ b/search-worker/src/no-sgx/app3.cc
@@ -97,21 +97,24 @@ int main(int argc, char* argv[]) {
   printf("content_len: %ld\n", content_len);
 
   {
-    bool status = worker0.Initialize(content.get(), content_len, 3, 0);
+    auto r = hakes::StringIOReader(content.get(), content_len);
+    bool status = worker0.Initialize(&r, nullptr, nullptr, false, 3, 0);
     if (!status) {
       printf("Failed to initialize\n");
       exit(1);
     }
   }
   {
-    bool status = worker1.Initialize(content.get(), content_len, 3, 1);
+    auto r = hakes::StringIOReader(content.get(), content_len);
+    bool status = worker1.Initialize(&r, nullptr, nullptr, false, 3, 1);
     if (!status) {
       printf("Failed to initialize\n");
       exit(1);
     }
   }
   {
-    bool status = worker2.Initialize(content.get(), content_len, 3, 2);
+    auto r = hakes::StringIOReader(content.get(), content_len);
+    bool status = worker2.Initialize(&r, nullptr, nullptr, false, 3, 2);
     if (!status) {
       printf("Failed to initialize\n");
       exit(1);
@@ -320,7 +323,6 @@ int main(int argc, char* argv[]) {
   worker0.Close();
   worker1.Close();
   worker2.Close();
-
 
   delete[] data;
   delete[] query;

--- a/search-worker/src/no-sgx/index_test.cpp
+++ b/search-worker/src/no-sgx/index_test.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+
+#include "message/searchservice.h"
+#include "search-worker/common/worker.h"
+#include "search-worker/common/workerImpl.h"
+#include "utils/data_loader.h"
+#include "utils/fileutil.h"
+
+struct Config {
+  size_t data_n = 1183514;
+  size_t data_num_query = 1000;
+  size_t data_dim = 200;
+  size_t search_k = 10;
+  size_t data_groundtruth_len = 100;
+  std::string data_train_path;
+  std::string data_query_path;
+  std::string data_groundtruth_path;
+  // index params
+  int nprobe = 1024;
+  int k_factor = 50;
+  std::string index_path;
+  std::string update_path = "";
+};
+
+Config parse_config(int argc, char** argv) {
+  Config cfg;
+  if (argc < 12) {
+    std::cout
+        << "Usage: " << argv[0]
+        << " DATA_N DATA_NUM_QUERY DATA_DIM SEARCH_K DATA_GROUNDTRUTH_LEN "
+           "DATA_TRAIN_PATH DATA_QUERY_PATH DATA_GROUNDTRUTH_PATH NPROBE "
+           "K_FACTOR INDEX_PATH UPDATE_PATH"
+        << std::endl;
+    exit(1);
+  }
+
+  cfg.data_n = std::stoul(argv[1]);
+  cfg.data_num_query = std::stoul(argv[2]);
+  cfg.data_dim = std::stoul(argv[3]);
+  cfg.search_k = std::stoul(argv[4]);
+  cfg.data_groundtruth_len = std::stoul(argv[5]);
+  cfg.data_train_path = argv[6];
+  cfg.data_query_path = argv[7];
+  cfg.data_groundtruth_path = argv[8];
+  cfg.nprobe = std::stoi(argv[9]);
+  cfg.k_factor = std::stoi(argv[10]);
+  cfg.index_path = argv[11];
+  if (argc > 12) {
+    cfg.update_path = argv[12];
+  }
+
+  std::cout << "DATA_N: " << cfg.data_n << std::endl;
+  std::cout << "DATA_NUM_QUERY: " << cfg.data_num_query << std::endl;
+  std::cout << "DATA_DIM: " << cfg.data_dim << std::endl;
+  std::cout << "SEARCH_K: " << cfg.search_k << std::endl;
+  std::cout << "DATA_GROUNDTRUTH_LEN: " << cfg.data_groundtruth_len
+            << std::endl;
+  std::cout << "DATA_TRAIN_PATH: " << cfg.data_train_path << std::endl;
+  std::cout << "DATA_QUERY_PATH: " << cfg.data_query_path << std::endl;
+  std::cout << "DATA_GROUNDTRUTH_PATH: " << cfg.data_groundtruth_path
+            << std::endl;
+  std::cout << "NPROBE: " << cfg.nprobe << std::endl;
+  std::cout << "K_FACTOR: " << cfg.k_factor << std::endl;
+  std::cout << "INDEX_PATH: " << cfg.index_path << std::endl;
+  std::cout << "UPDATE_PATH: " << cfg.update_path << std::endl;
+  return cfg;
+}
+
+int main(int argc, char* argv[]) {
+  // Config cfg;
+  Config cfg = parse_config(argc, argv);
+  int n = cfg.data_n;
+  int d = cfg.data_dim;
+  int nq = cfg.data_num_query;
+  int gt_len = cfg.data_groundtruth_len;
+  int k = cfg.search_k;
+
+  // search_worker::WorkerImpl worker{};
+  std::unique_ptr<faiss::HakesIndex> index(new faiss::HakesIndex());
+  index->use_ivf_sq_ = true;
+  index->use_refine_sq_ = false;
+
+  size_t content_len = 0;
+  auto content =
+      hakes::ReadFileToCharArray(cfg.index_path.c_str(), &content_len);
+
+  printf("content_len: %ld\n", content_len);
+
+  hakes::StringIOReader reader(content.get(), content_len);
+  if (cfg.update_path.empty()) {
+    index->Initialize(&reader, nullptr, nullptr, false);
+  } else {
+    auto update_content =
+        hakes::ReadFileToCharArray(cfg.update_path.c_str(), &content_len);
+    hakes::StringIOReader update_reader(update_content.get(), content_len);
+    index->Initialize(&reader, nullptr, &update_reader, false);
+  }
+
+  std::cout << "Index loaded" << std::endl;
+  std::cout << index->to_string() << std::endl;
+
+  if (false) {
+    auto base_index =
+        dynamic_cast<faiss::IndexIVFPQFastScanL*>(index->base_index_.get());
+    if (base_index == nullptr) {
+      std::cerr << "base index is not IndexIVFPQFastScanL" << std::endl;
+      return 1;
+    }
+    int nlist = base_index->quantizer->ntotal;
+
+    auto vt = dynamic_cast<faiss::LinearTransform*>(index->vts_[0]);
+    printf("########## vt (%dx%d) ##########\n", vt->d_out, vt->d_in);
+    printf("A\n");
+    for (int i = 0; i < vt->d_out; i++) {
+      for (int j = 0; j < vt->d_in; j++) {
+        printf("%8.4f ", vt->A[i * vt->d_in + j]);
+      }
+      printf("\n");
+    }
+    if (vt->have_bias) {
+      printf("b\n");
+      for (int i = 0; i < vt->d_out; i++) {
+        printf("%8.4f ", vt->b[i]);
+      }
+    } else {
+      printf("no bias\n");
+    }
+    printf("########## vt (%dx%d) ##########\n", vt->d_out, vt->d_in);
+
+    // dispplay the centroids of the coarse quantizer
+    printf("########## centroids (count: %d) ##########\n", nlist);
+    if (!index->use_ivf_sq_) {
+      auto cq = dynamic_cast<faiss::IndexFlatL*>(base_index->quantizer);
+      const float* centroids = cq->get_xb();
+      for (int i = 0; i < nlist; i++) {
+        printf("c%04d: ", i);
+        for (int j = 0; j < cq->d; j++) {
+          printf("%8.4f ", centroids[i * cq->d + j]);
+        }
+        printf("\n");
+      }
+    } else {
+      printf("use ivf sq\n");
+    }
+    printf("########## centroids (count: %d) ##########\n", nlist);
+    // int ksub = index->pq.ksub;
+    // int dsub = index->pq.dsub;
+    int ksub = base_index->pq.ksub;
+    int dsub = base_index->pq.dsub;
+    int pqm = base_index->pq.M;
+    printf("########## pq codebook (%dx%dx%d) ##########\n", pqm, ksub, dsub);
+    float* codebook = base_index->pq.centroids.data();
+    for (int j = 0; j < ksub; j++) {
+      printf("|");
+      for (int m = 0; m < pqm; m++) {
+        for (int k = 0; k < dsub; k++) {
+          printf("%8.4f ", codebook[(m * ksub + j) * dsub + k]);
+        }
+        printf("|");
+      }
+      printf("\n");
+    }
+    printf("########## pq codebook (%dx%dx%d) ##########\n", pqm, ksub, dsub);
+    if (index->has_q_index_) {
+      auto vt = dynamic_cast<faiss::LinearTransform*>(index->q_vts_[0]);
+      printf("########## vt (%dx%d) ##########\n", vt->d_out, vt->d_in);
+      printf("A\n");
+      for (int i = 0; i < vt->d_out; i++) {
+        for (int j = 0; j < vt->d_in; j++) {
+          printf("%8.4f ", vt->A[i * vt->d_in + j]);
+        }
+        printf("\n");
+      }
+      if (vt->have_bias) {
+        printf("b\n");
+        for (int i = 0; i < vt->d_out; i++) {
+          printf("%8.4f ", vt->b[i]);
+        }
+      } else {
+        printf("no bias\n");
+      }
+      printf("########## vt (%dx%d) ##########\n", vt->d_out, vt->d_in);
+      printf("########## centroids (count: %d) ##########\n", nlist);
+      if (!index->use_ivf_sq_) {
+        auto cq = dynamic_cast<faiss::IndexFlatL*>(index->q_cq_);
+        const float* centroids = cq->get_xb();
+        for (int i = 0; i < nlist; i++) {
+          printf("c%04d: ", i);
+          for (int j = 0; j < cq->d; j++) {
+            printf("%8.4f ", centroids[i * cq->d + j]);
+          }
+          printf("\n");
+        }
+      } else {
+        printf("use ivf sq\n");
+      }
+      printf("########## centroids (count: %d) ##########\n", nlist);
+    }
+    if (base_index->has_q_pq) {
+      printf("########## qpq codebook (%dx%dx%d) ##########\n", pqm, ksub,
+             dsub);
+      float* codebook = base_index->q_pq.centroids.data();
+      for (int j = 0; j < ksub; j++) {
+        printf("|");
+        for (int m = 0; m < pqm; m++) {
+          for (int k = 0; k < dsub; k++) {
+            printf("%8.4f ", codebook[(m * ksub + j) * dsub + k]);
+          }
+          printf("|");
+        }
+        printf("\n");
+      }
+      printf("########## pq codebook (%dx%dx%d) ##########\n", pqm, ksub, dsub);
+    }
+  }
+
+  // load data files
+  float* data =
+      load_data(cfg.data_train_path.c_str(), cfg.data_dim, cfg.data_n);
+  float* query =
+      load_data(cfg.data_query_path.c_str(), cfg.data_dim, cfg.data_num_query);
+  int* groundtruth =
+      load_groundtruth(cfg.data_groundtruth_path.c_str(),
+                       cfg.data_groundtruth_len, cfg.data_num_query);
+
+  // add
+
+  auto xids = std::make_unique<faiss::idx_t[]>(n);
+  for (int i = 0; i < n; i++) {
+    xids[i] = i;
+  }
+  std::unique_ptr<faiss::idx_t[]> assign = std::make_unique<faiss::idx_t[]>(n);
+  int vecs_t_d;
+  std::unique_ptr<float[]> vecs_t;
+
+  auto batch_size = 100000;
+  for (int i = 0; i < n; i += batch_size) {
+    index->AddWithIds(std::min(batch_size, n - i), d, data + i * d,
+                      xids.get() + i, assign.get() + i, &vecs_t_d, &vecs_t);
+
+    std::cout << "Inserted " << i << " vector" << std::endl;
+  }
+
+  std::cout << "Index: " << index->to_string() << std::endl;
+
+  {
+    index->base_index_->use_early_termination_ = true;
+    index->base_index_->et_params.beta = 200;
+    index->base_index_->et_params.ce = 30;
+  }
+
+  auto nprobe_list = std::vector<int>{1, 5, 10, 50, 100, 200, 300};
+  auto k_factor_list = std::vector<int>{1, 10, 20, 50, 100, 200, 300};
+
+  for (auto nprobe : nprobe_list) {
+    for (auto k_factor : k_factor_list) {
+      auto k_base = k * k_factor;
+      faiss::HakesSearchParams params{nprobe, k, k_factor,
+                                      faiss::METRIC_INNER_PRODUCT};
+
+      auto result = std::make_unique<faiss::idx_t[]>(k * nq);
+      auto start = std::chrono::high_resolution_clock::now();
+
+      for (int i = 0; i < nq; ++i) {
+        // printf("\nquery %d: ", i);
+        std::unique_ptr<faiss::idx_t[]> candidates;
+        std::unique_ptr<float[]> distances;
+        index->Search(1, d, query + i * d, params, &distances, &candidates);
+        std::unique_ptr<faiss::idx_t[]> k_base_count =
+            std::make_unique<faiss::idx_t[]>(1);
+        k_base_count[0] = k_base;
+        index->Rerank(1, d, query + i * d, k, k_base_count.get(),
+                      candidates.get(), distances.get(), &distances,
+                      &candidates);
+        std::memcpy(result.get() + i * k, candidates.get(),
+                    k * sizeof(faiss::idx_t));
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double> diff = end - start;
+
+      int correct = 0;
+      for (int i = 0; i < nq; i++) {
+        std::unordered_set<int> gts(k);
+        for (int j = 0; j < k; j++) {
+          gts.insert(groundtruth[i * gt_len + j]);
+        }
+
+        for (int j = 0; j < k; j++) {
+          if (gts.find(result[i * k + j]) != gts.end()) {
+            correct++;
+          }
+        }
+      }
+
+      std::cout << "nprobe: " << nprobe << " k_factor: " << k_factor
+                << " search time (s): " << diff.count()
+                << " recall: " << correct / (float)(nq * k) << std::endl;
+    }
+  }
+
+  delete[] data;
+  delete[] query;
+  delete[] groundtruth;
+  return 0;
+}

--- a/utils/io.cpp
+++ b/utils/io.cpp
@@ -1,0 +1,30 @@
+#include "utils/io.h"
+
+#include <cstring>
+
+namespace hakes {
+/**
+ * streamlined functions from index_read.cpp and index_write.cpp
+ */
+
+size_t StringIOWriter::operator()(const void* ptr, size_t size, size_t nitems) {
+  size_t bytes = size * nitems;
+  if (bytes > 0) {
+    size_t o = data.size();
+    data.resize(o + bytes);
+    memcpy(&data[o], ptr, size * nitems);
+  }
+  return nitems;
+}
+
+size_t StringIOReader::operator()(void* ptr, size_t size, size_t nitems) {
+  if (rp >= data_len) return 0;
+  size_t nremain = (data_len - rp) / size;
+  if (nremain < nitems) nitems = nremain;
+  if (size * nitems > 0) {
+    memcpy(ptr, data + rp, size * nitems);
+    rp += size * nitems;
+  }
+  return nitems;
+}
+}  // namespace hakes

--- a/utils/io.h
+++ b/utils/io.h
@@ -39,6 +39,24 @@ struct StringIOWriter : IOWriter {
   size_t operator()(const void* ptr, size_t size, size_t nitems) override;
 };
 
+struct FileIOReader : IOReader {
+  FILE* f;
+  bool need_close;
+  FileIOReader(FILE* f) : f(f), need_close(false) {}
+  FileIOReader(const char* fname);
+  ~FileIOReader() override;
+  size_t operator()(void* ptr, size_t size, size_t nitems) override;
+};
+
+struct FileIOWriter : IOWriter {
+  FILE* f;
+  bool need_close;
+  FileIOWriter(FILE* f) : f(f), need_close(false) {}
+  FileIOWriter(const char* fname);
+  ~FileIOWriter() override;
+  size_t operator()(const void* ptr, size_t size, size_t nitems) override;
+};
+
 }  // namespace hakes
 
 #endif  // HAKES_UTILS_IO_H_

--- a/utils/io.h
+++ b/utils/io.h
@@ -1,0 +1,44 @@
+#ifndef HAKES_UTILS_IO_H_
+#define HAKES_UTILS_IO_H_
+
+#include <string>
+
+namespace hakes {
+
+struct IOReader {
+  // name that can be used in error messages
+  std::string name;
+
+  // fread. Returns number of items read or 0 in case of EOF.
+  virtual size_t operator()(void* ptr, size_t size, size_t nitems) = 0;
+
+  virtual ~IOReader() {}
+};
+
+struct IOWriter {
+  // name that can be used in error messages
+  std::string name;
+
+  // fwrite. Return number of items written
+  virtual size_t operator()(const void* ptr, size_t size, size_t nitems) = 0;
+
+  virtual ~IOWriter() noexcept(false) {}
+};
+
+struct StringIOReader : IOReader {
+  StringIOReader(const char* data, size_t data_len)
+      : data(data), data_len(data_len) {}
+  const char* data;
+  size_t data_len;
+  size_t rp = 0;
+  size_t operator()(void* ptr, size_t size, size_t nitems) override;
+};
+
+struct StringIOWriter : IOWriter {
+  std::string data;
+  size_t operator()(const void* ptr, size_t size, size_t nitems) override;
+};
+
+}  // namespace hakes
+
+#endif  // HAKES_UTILS_IO_H_


### PR DESCRIPTION
# Description

This PR contains the latest development on HAKES vector index migrated over to the HAKES main repo.

## Changes

* Support for ivf scalar quantization
* Support for MKL for non-sgx search-worker (MKL is much faster than the blas impl that was introduced for SGX support)
* Support separate management of query index parameters
* Support early termination for search in HAKES index
* Update the index loading APIs 
* Update non-sgx server
* Update non-sgx docker

## Follow-up

Support of server (sgx) will be updated in a subsequent PR.
