### PR TITLE
style: settle down clang-format style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle: Google
+IndentWidth: 2


### PR DESCRIPTION
This PR creates a `.clang-format` file to override any user-specific formatting in VS Code, ensuring a consistent coding convention.