### PR TITLE
fix: index save and load improvement

### DIFF
--- a/search-worker/index/ext/BlockInvertedListsL.cpp
+++ b/search-worker/index/ext/BlockInvertedListsL.cpp
@@ -116,22 +116,12 @@ BlockInvertedListsL::BlockInvertedListsL(size_t nlist, size_t vec_per_block,
   lists_.resize(nlist);
 }
 
-void BlockInvertedListsL::init(const CodePacker* packer,
-                               const std::vector<int>& load_list,
-                               size_t init_list_cap) {
+void BlockInvertedListsL::init(const CodePacker* packer, size_t init_list_cap) {
   if (this->packer_) {
     delete this->packer_;
   }
   this->packer_ = packer;
-  this->load_list_ = load_list;
-  if (this->load_list_.empty()) {
-    // load all the list
-    this->load_list_.resize(nlist);
-    for (size_t i = 0; i < nlist; i++) {
-      this->load_list_[i] = i;
-    }
-  }
-  for (auto idx : this->load_list_) {
+  for (int idx = 0; idx < nlist; idx++) {
     this->lists_[idx].set_active(n_per_block_, block_size_, init_list_cap);
   }
 }

--- a/search-worker/index/ext/BlockInvertedListsL.h
+++ b/search-worker/index/ext/BlockInvertedListsL.h
@@ -101,13 +101,11 @@ struct BlockInvertedListsL : InvertedLists {
   const CodePacker* packer_ = nullptr;
 
   std::vector<InvListUnit> lists_;
-  std::vector<int> load_list_;
 
   explicit BlockInvertedListsL(size_t nlist, size_t vec_per_block,
                                size_t block_size);
 
-  void init(const CodePacker* packer, const std::vector<int>& load_list,
-            size_t init_list_cap = 0);
+  void init(const CodePacker* packer, size_t init_list_cap = 0);
 
   void set_code_packer(const CodePacker* packer);
 

--- a/search-worker/index/ext/IndexIVFFastScanL.cpp
+++ b/search-worker/index/ext/IndexIVFFastScanL.cpp
@@ -85,7 +85,7 @@ void IndexIVFFastScanL::init_fastscan(size_t M, size_t nbits, size_t nlist,
   is_trained = false;
   auto packer = get_CodePacker();  // will be owned by the lists
   auto lists = new BlockInvertedListsL(nlist, packer->nvec, packer->block_size);
-  lists->init(packer, std::vector<int>());  // no specification of load list
+  lists->init(packer);  // no specification of load list
   replace_invlists(lists, true);
 }
 

--- a/search-worker/index/impl/io_macros.h
+++ b/search-worker/index/impl/io_macros.h
@@ -8,6 +8,8 @@
 #ifndef HAKES_SEARCHWORKER_INDEX_IMPL_IOMACRO_H_
 #define HAKES_SEARCHWORKER_INDEX_IMPL_IOMACRO_H_
 
+#include <cstdint>
+
 /*************************************************************
  * I/O macros
  *
@@ -18,7 +20,7 @@
 
 #define READANDCHECK(ptr, n)                         \
     {                                                \
-        size_t ret = (*f)(ptr, sizeof(*(ptr)), n);   \
+        uint64_t ret = (*f)(ptr, sizeof(*(ptr)), n);   \
         assert(ret == (n));                          \
     }
 
@@ -27,7 +29,7 @@
 // will fail if we write 256G of data at once...
 #define READVECTOR(vec)                                              \
     {                                                                \
-        size_t size;                                                 \
+        uint64_t size;                                                 \
         READANDCHECK(&size, 1);                                      \
         assert(size >= 0 && size < (uint64_t{1} << 40)); \
         (vec).resize(size);                                          \
@@ -36,14 +38,14 @@
 
 #define READSTRING(s)                     \
     {                                     \
-        size_t size = (s).size();         \
+        uint64_t size = (s).size();         \
         WRITEANDCHECK(&size, 1);          \
         WRITEANDCHECK((s).c_str(), size); \
     }
 
 #define WRITEANDCHECK(ptr, n)                         \
     {                                                 \
-        size_t ret = (*f)(ptr, sizeof(*(ptr)), n);    \
+        uint64_t ret = (*f)(ptr, sizeof(*(ptr)), n);    \
         assert(ret == (n));                           \
     }
 
@@ -51,7 +53,7 @@
 
 #define WRITEVECTOR(vec)                   \
     {                                      \
-        size_t size = (vec).size();        \
+        uint64_t size = (vec).size();        \
         WRITEANDCHECK(&size, 1);           \
         WRITEANDCHECK((vec).data(), size); \
     }
@@ -61,14 +63,14 @@
 #define WRITEXBVECTOR(vec)                         \
     {                                              \
         assert((vec).size() % 4 == 0); \
-        size_t size = (vec).size() / 4;            \
+        uint64_t size = (vec).size() / 4;            \
         WRITEANDCHECK(&size, 1);                   \
         WRITEANDCHECK((vec).data(), size * 4);     \
     }
 
 #define READXBVECTOR(vec)                                            \
     {                                                                \
-        size_t size;                                                 \
+        uint64_t size;                                                 \
         READANDCHECK(&size, 1);                                      \
         assert(size >= 0 && size < (uint64_t{1} << 40)); \
         size *= 4;                                                   \


### PR DESCRIPTION
# Summary

Remove unused fields for the compressed vector lists and avoid storing compressed vectors meta if it is empty. It is also intended to keep just the necessary information so that the python tool that generate index parameters store them in succinct format for loading in search worker.

Moreover, `size_t` is replaced with `uint32_t` or `uint64_t` to fix the bits of representation in the storage format. 
