### PR TITLE
fix(server): segmentation fault without UV_THREADPOOL_SIZE

### DIFF
--- a/search-worker/no_sgx.mk
+++ b/search-worker/no_sgx.mk
@@ -9,9 +9,13 @@ MKL_LIBRARY_PATH ?= $(HOME)/intel/oneapi/mkl/2024.0/lib/
 WARNING_IGNORE = -Wno-sign-compare -Wno-unused-variable -Wno-comment -Wno-unused-function -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-type-limits
 COMMON_FLAGS = -fpic -fopenmp -ftree-vectorize -Wall -Wextra $(WARNING_IGNORE)
 ifeq ($(DEBUG), 1)
-	COMMON_FLAGS += -march=native -O2 -g -fsanitize=address
+	COMMON_FLAGS += -march=native -O2 -g
 else
 	COMMON_FLAGS += -Ofast -march=native
+endif
+
+ifeq ($(ASAN), 1)
+	COMMON_FLAGS += -fsanitize=address
 endif
 
 App_Cpp_Flags = -std=c++17 $(COMMON_FLAGS)
@@ -146,7 +150,11 @@ Server_Additional_Include_Flags := -Iserver -I$(LIBUV_DIR)/include -I$(LLHTTP_DI
 Server_Additional_Link_Flags := -L$(LIBUV_DIR)/lib -l:libuv_a.a -L$(LLHTTP_DIR)/lib -l:libllhttp.a -lrt -ldl
 
 ifeq ($(DEBUG), 1)
-	Server_Additional_Link_Flags += -g -fsanitize=address
+	Server_Additional_Link_Flags += -g
+endif
+
+ifeq ($(ASAN), 1)
+	Server_Additional_Link_Flags += -fsanitize=address
 endif
 
 server/no-sgx/service.o: $(HAKES_ROOT_DIR)/server/service.cpp

--- a/server/server.h
+++ b/server/server.h
@@ -38,11 +38,15 @@ std::string build_response(response_code_t code, const std::string& msg);
 class Server {
  public:
   Server(long port, Service* svc) : port_(port), service_(svc) {
-    try {
-      printf("worker pool size: %d\n", atoi(getenv("UV_THREADPOOL_SIZE")));
-    } catch (const std::exception& e) {
-      printf("UV_THREADPOOL_SIZE not set\n");
-      exit(1);
+    int uv_threadpool_size = 1;
+
+    char* threadpool_size_str = std::getenv("UV_THREADPOOL_SIZE");
+    if (threadpool_size_str == nullptr) {
+      printf("UV_THREADPOOL_SIZE not set. worker pool size defaulting to %d\n",
+             uv_threadpool_size);
+    } else {
+      uv_threadpool_size = std::atoi(threadpool_size_str);
+      printf("worker pool size: %d\n", uv_threadpool_size);
     }
   };
   virtual ~Server();


### PR DESCRIPTION
This PR
- fixes an issue where not setting UV_THREADPOOL_SIZE causes search-worker to segfault
- in Makefile, add a new ASAN variable apart from DEBUG. This allows gdb to better handle debugging process (without interfered by ASAN)

Now, to only enable debugging symbols, build with 
```bash
DEBUG=1 make no_sgx -j
```

If also needs ASAN, build with 
```bash
DEBUG=1 ASAN=1 make no_sgx -j
```