### PR TITLE
feat(search) expose search worker checkpointing

### DIFF
--- a/client/py/hakesclient/message.py
+++ b/client/py/hakesclient/message.py
@@ -90,7 +90,7 @@ def decode_search_worker_search_response(
         .reshape(-1, k)
         .tolist()
     )
-    scores =(
+    scores = (
         np.frombuffer(bytes.fromhex(resp["scores"]), dtype=np.float32)
         .reshape(-1, k)
         .tolist()
@@ -149,6 +149,7 @@ def decode_search_worker_rerank_response(resp: Dict, k: int) -> Dict:
     )
     return resp
 
+
 def encode_search_worker_delete_request(collection_name: str, ids: np.ndarray):
     data = {
         "collection_name": collection_name,
@@ -159,3 +160,16 @@ def encode_search_worker_delete_request(collection_name: str, ids: np.ndarray):
 
 def decode_search_worker_delete_response(resp: Dict) -> Dict:
     return {"status": resp["status"], "msg": resp["msg"]}
+
+
+def encode_search_worker_checkpoint_request(
+    collection_name: str,
+):
+    data = {
+        "collection_name": collection_name,
+    }
+    return data
+
+
+def decode_search_worker_checkpoint_response(resp: Dict) -> Dict:
+    return resp

--- a/message/searchservice.cpp
+++ b/message/searchservice.cpp
@@ -300,4 +300,46 @@ bool decode_search_worker_delete_response(
   return true;
 }
 
+std::string encode_search_worker_checkpoint_request(
+    const SearchWorkerCheckpointRequest& request) {
+  json::JSON ret;
+  ret["collection_name"] = request.collection_name;
+  if (!request.ks_addr.empty()) {
+    ret["user_id"] = request.user_id;
+    ret["ks_addr"] = request.ks_addr;
+    ret["ks_port"] = request.ks_port;
+  }
+  return ret.dump();
+}
+
+bool decode_search_worker_checkpoint_request(
+    const std::string& request_str, SearchWorkerCheckpointRequest* request) {
+  auto input = json::JSON::Load(request_str);
+  request->collection_name = input["collection_name"].ToString();
+  if (input.hasKey("ks_addr")) {
+    request->user_id = input["user_id"].ToString();
+    request->ks_addr = input["ks_addr"].ToString();
+    request->ks_port = input["ks_port"].ToInt();
+  }
+  return true;
+}
+
+std::string encode_search_worker_checkpoint_response(
+    const SearchWorkerCheckpointResponse& response) {
+  json::JSON ret;
+  ret["status"] = response.status;
+  ret["msg"] = response.msg;
+  ret["aux"] = response.aux;
+  return ret.dump();
+}
+
+bool decode_search_worker_checkpoint_response(
+    const std::string& response_str, SearchWorkerCheckpointResponse* response) {
+  auto input = json::JSON::Load(response_str);
+  response->status = input["status"].ToBool();
+  response->msg = input["msg"].ToString();
+  response->aux = input["aux"].ToString();
+  return true;
+}
+
 }  // namespace hakes

--- a/message/searchservice.h
+++ b/message/searchservice.h
@@ -175,6 +175,31 @@ std::string encode_search_worker_delete_response(
 bool decode_search_worker_delete_response(const std::string& response_str,
                                           SearchWorkerDeleteResponse* response);
 
+struct SearchWorkerCheckpointRequest {
+  std::string collection_name;
+  std::string user_id;
+  std::string ks_addr;
+  uint16_t ks_port = 0;
+};
+
+std::string encode_search_worker_checkpoint_request(
+    const SearchWorkerCheckpointRequest& request);
+
+bool decode_search_worker_checkpoint_request(
+    const std::string& request_str, SearchWorkerCheckpointRequest* request);
+
+struct SearchWorkerCheckpointResponse {
+  bool status;
+  std::string msg;
+  std::string aux;
+};
+
+std::string encode_search_worker_checkpoint_response(
+    const SearchWorkerCheckpointResponse& response);
+
+bool decode_search_worker_checkpoint_response(
+    const std::string& response_str, SearchWorkerCheckpointResponse* response);
+
 }  // namespace hakes
 
 #endif  // HAKES_MESSAGE_SEARCHSERVICE_H_

--- a/search-worker/include/search-worker/common/checkpoint.h
+++ b/search-worker/include/search-worker/common/checkpoint.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HAKES_SERVING_UTILS_CHECKPOINT_H_
+#define HAKES_SERVING_UTILS_CHECKPOINT_H_
+
+#include <stdexcept>
+#include <string>
+
+namespace hakes {
+
+/**
+ * @brief The format of checkpoint directory is in the form of
+ * "checkpoint_%d"
+ *
+ */
+const char CheckpointDirPrefix[] = "checkpoint_";
+
+std::string get_latest_checkpoint_path(const std::string& path);
+
+inline std::string format_checkpoint_path(int checkpoint_no) {
+  // return checkpoint_%06d
+  return CheckpointDirPrefix + std::to_string(checkpoint_no);
+}
+
+inline int get_checkpoint_no(const std::string& path) {
+  if (path.find(CheckpointDirPrefix) != 0) {
+    return -1;
+  }
+  std::string suffix = path.substr(std::string(CheckpointDirPrefix).size());
+  try {
+    auto checkpoint_no = std::stoi(suffix);
+    return checkpoint_no;
+  } catch (...) {
+    return -1;
+  }
+}
+
+}  // namespace hakes
+
+#endif  // HAKES_SERVING_UTILS_CHECKPOINT_H_

--- a/search-worker/include/search-worker/common/worker.h
+++ b/search-worker/include/search-worker/common/worker.h
@@ -28,12 +28,13 @@ class Worker {
   Worker() = default;
   virtual ~Worker() {}
 
-  virtual bool Initialize(bool keep_pa, int cluster_size, int server_id, const std::string &path) = 0;
+  virtual bool Initialize(bool keep_pa, int cluster_size, int server_id,
+                          const std::string& path) = 0;
 
   // the worker shall be pre-initialized before installing to a search worker
   virtual bool IsInitialized() = 0;
 
-  virtual bool HasLoadedCollection(const std::string &collection_name) = 0;
+  virtual bool HasLoadedCollection(const std::string& collection_name) = 0;
 
   virtual bool LoadCollection(const char* req, size_t req_len, char* resp,
                               size_t resp_len) = 0;
@@ -49,6 +50,9 @@ class Worker {
 
   virtual bool Delete(const char* req, size_t req_len, char* resp,
                       size_t resp_len) = 0;
+
+  virtual bool Checkpoint(const char* req, size_t req_len, char* resp,
+                          size_t resp_len) = 0;
 
   virtual bool Close() = 0;
 };

--- a/search-worker/include/search-worker/common/workerImpl.h
+++ b/search-worker/include/search-worker/common/workerImpl.h
@@ -55,6 +55,9 @@ class WorkerImpl : public Worker {
   bool Delete(const char* req, size_t req_len, char* resp,
               size_t resp_len) override;
 
+  bool Checkpoint(const char* req, size_t req_len, char* resp,
+                  size_t resp_len) override;
+
   bool Close() override;
 
  private:

--- a/search-worker/index/ext/HakesCollection.h
+++ b/search-worker/index/ext/HakesCollection.h
@@ -17,6 +17,8 @@
 #ifndef HAKES_SEARCHWORKER_INDEX_EXT_HAKESCOLLECTION_H_
 #define HAKES_SEARCHWORKER_INDEX_EXT_HAKESCOLLECTION_H_
 
+#include <atomic>
+
 #include "search-worker/index/VectorTransform.h"
 #include "search-worker/index/ext/IdMap.h"
 #include "search-worker/index/ext/IndexFlatL.h"
@@ -74,6 +76,15 @@ class HakesCollection {
   virtual bool DeleteWithIds(int n, const faiss::idx_t* ids) = 0;
 
   virtual std::string to_string() const = 0;
+
+  inline bool is_loaded() const {
+    return loaded_.load(std::memory_order_relaxed);
+  }
+
+  inline void set_loaded() { loaded_.store(true, std::memory_order_relaxed); }
+
+  std::atomic<bool> loaded_ = false;
+  std::atomic<uint32_t> index_version_ = 0;
 };
 
 }  // namespace faiss

--- a/search-worker/no_sgx.mk
+++ b/search-worker/no_sgx.mk
@@ -61,6 +61,11 @@ src/no-sgx/json.o: ${HAKES_ROOT_DIR}/utils/json.cpp
 src/no-sgx/searchservice.o: ${HAKES_ROOT_DIR}/message/searchservice.cpp
 	$(CXX) ${App_Cpp_Flags} -c $< -o $@
 	@echo "CXX <= $<"
+
+src/no-sgx/checkpoint.o: src/no-sgx/checkpoint.cpp
+	$(CXX) ${App_Cpp_Flags} -c $< -o $@
+	@echo "CXX <= $<"
+
 ## other srcs
 
 src/no-sgx/worker.o: src/common/worker.cc
@@ -77,6 +82,7 @@ Objects := src/no-sgx/worker.o \
 	src/no-sgx/fileutil.o \
 	src/no-sgx/hexutil.o \
 	src/no-sgx/json.o \
+	src/no-sgx/checkpoint.o \
 	src/no-sgx/searchservice.o \
 	src/no-sgx/index-build/ext/BlockInvertedListsL.o \
 	src/no-sgx/index-build/ext/HakesIndex.o \

--- a/search-worker/server/no-sgx/main.cpp
+++ b/search-worker/server/no-sgx/main.cpp
@@ -73,4 +73,4 @@ int main(int argc, char* argv[]) {
   return 0;
 }
 
-// ./sample-server 2351 path
+// ./sample-server 2351 path 1 0

--- a/search-worker/server/search_worker.cpp
+++ b/search-worker/server/search_worker.cpp
@@ -20,6 +20,9 @@
 #include <cstring>
 
 namespace search_worker {
+
+const uint32_t kMaxRespLen = 4 << 20;
+
 SearchWorker::~SearchWorker() {
   if (initialized_) {
     Close();
@@ -43,32 +46,37 @@ bool SearchWorker::Handle(const std::string& url, const std::string& input,
                           std::string* output) {
   assert(initialized_);
   // allocate 1MB buffer
-  std::unique_ptr<char[]> buf = std::make_unique<char[]>(1024 * 1024);
-  memset(&buf[0], 0, 1024 * 1024);
+  std::unique_ptr<char[]> buf = std::make_unique<char[]>(kMaxRespLen);
+  memset(&buf[0], 0, kMaxRespLen);
 
   if (url == "/add") {
     auto success = worker_->AddWithIds(input.c_str(), input.size(), buf.get(),
-                                       1024 * 1024);
+                                       kMaxRespLen);
     output->assign(&buf[0]);
     return success;
   } else if (url == "/search") {
-    auto success = worker_->Search(input.c_str(), input.size(), buf.get(),
-                                   1024 * 1024);
+    auto success =
+        worker_->Search(input.c_str(), input.size(), buf.get(), kMaxRespLen);
     output->assign(&buf[0]);
     return success;
   } else if (url == "/rerank") {
-    auto success = worker_->Rerank(input.c_str(), input.size(), buf.get(),
-                                   1024 * 1024);
+    auto success =
+        worker_->Rerank(input.c_str(), input.size(), buf.get(), kMaxRespLen);
     output->assign(&buf[0]);
     return success;
   } else if (url == "/load") {
-    auto success = worker_->LoadCollection(input.c_str(), input.size(), buf.get(),
-                                   1024 * 1024);
+    auto success = worker_->LoadCollection(input.c_str(), input.size(),
+                                           buf.get(), kMaxRespLen);
     output->assign(&buf[0]);
     return success;
   } else if (url == "/delete") {
-    auto success = worker_->Delete(input.c_str(), input.size(), buf.get(),
-                                   1024 * 1024);
+    auto success =
+        worker_->Delete(input.c_str(), input.size(), buf.get(), kMaxRespLen);
+    output->assign(&buf[0]);
+    return success;
+  } else if (url == "/checkpoint") {
+    auto success = worker_->Checkpoint(input.c_str(), input.size(), buf.get(),
+                                       kMaxRespLen);
     output->assign(&buf[0]);
     return success;
   }

--- a/search-worker/src/no-sgx/checkpoint.cpp
+++ b/search-worker/src/no-sgx/checkpoint.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The HAKES Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "search-worker/common/checkpoint.h"
+
+#include <filesystem>
+
+namespace hakes {
+
+std::string get_latest_checkpoint_path(const std::string& path) {
+  std::string last_checkpoint;
+  std::string prefix = CheckpointDirPrefix;
+  int latest_checkpoint_no = -1;
+  // get the directory with matching prefix and largest suffix number
+  for (const auto& entry : std::filesystem::directory_iterator(path)) {
+    auto fname = entry.path().filename().string();
+    if (!entry.is_directory() || fname.find(prefix) != 0) {
+      continue;
+    }
+    std::string suffix = fname.substr(prefix.size());
+    try {
+      int checkpoint_no = std::stoi(suffix);
+      if (checkpoint_no > latest_checkpoint_no) {
+        latest_checkpoint_no = checkpoint_no;
+        last_checkpoint = fname;
+      }
+    } catch (...) {
+      continue;
+    }
+  }
+  return last_checkpoint;
+}
+
+}  // namespace hakes


### PR DESCRIPTION
# Summary

Expose the index checkpointing support at search worker APIs. Checkpoint of a collection write the index being hosted according to the serving mode. Under collection directory, checkpoints are named as `checkpoint_x`, where x is version number that is incremented by 1. The latest checkpoint of a collection is loaded.

* checkpoint management for each collection
* the data path passed to search worker should have the following organization: path/collection_name/checkpoint_x
* python client updated to support checkpointing for single search worker deployment
