### PR TITLE
fix: reload loaded collection causes null ptr reference

### DIFF
--- a/search-worker/src/worker.cpp
+++ b/search-worker/src/worker.cpp
@@ -114,6 +114,7 @@ bool WorkerImpl::LoadCollection(const char* req, size_t req_len, char* resp,
     load_resp.msg = "load error: " + load_resp.msg;
   } else {
     load_resp.status = true;
+    index = GetCollection(collection_name);
     load_resp.msg =
         "load success: " + collection_name + "{" + index->to_string() + "}";
   }

--- a/search-worker/test/worker_test.cpp
+++ b/search-worker/test/worker_test.cpp
@@ -84,6 +84,9 @@ int main(int argc, char* argv[]) {
       hakes::encode_search_worker_load_request(load_req);
   assert(worker.LoadCollection(encoded_load_req.c_str(), encoded_load_req.size(),
                                resp_load.get(), 4096 * 4096));
+  //  reloading shall be noop
+  assert(worker.LoadCollection(encoded_load_req.c_str(), encoded_load_req.size(),
+                               resp_load.get(), 4096 * 4096));
   std::cout << "Index loaded" << std::endl;
 
   // add vectors.


### PR DESCRIPTION
# Summary

The problem is that when the collection is already loaded, we did not fetch the corresponding index instance before calling to_string method. @YingHongBin 